### PR TITLE
Adding defaultSchemeString

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ final class UserViewController: UIViewController, URLNavigable {
         }
         self.init(userID: userID)
     }
-    
+
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -115,7 +115,7 @@ Installation
         ]
     )
     ```
-    
+
 
 Tips and Tricks
 ---------------
@@ -156,7 +156,7 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
                      didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
         // Navigator
         URLNavigationMap.initialize()
-        
+
         // Do something else...
     }
 }
@@ -229,6 +229,20 @@ Then use `Navigator.openURL()` instead of `Navigator.pushURL()`:
 
 ```swift
 Navigator.openURL("myapp://post/12345")
+```
+
+#### Simplify URL mapping with  Global URL Scheme
+Avoid to add URL scheme in all URLs using a global scheme definition
+
+```swift
+URLNavigator.defaultSchemeString = "myapp"
+
+Navigator.map("/user/<int:id>", UserViewController.self)
+Navigator.map("/post/<title>", PostViewController.self)
+
+
+Navigator.openURL("/post/12345")
+
 ```
 
 

--- a/Sources/URLNavigator.swift
+++ b/Sources/URLNavigator.swift
@@ -65,6 +65,9 @@ public class URLNavigator {
 
     /// A dictionary to store URLOpenHandlers by URL patterns.
     private(set) var URLOpenHandlers = [String: URLOpenHandler]()
+    
+    /// String with the value of the fallback scheme when normalize the url
+    public static var defaultSchemeString:String?
 
 
     // MARK: Initializing
@@ -313,7 +316,13 @@ public class URLNavigator {
         guard dirtyURL.URLValue != nil else {
             return dirtyURL
         }
+
         var URLString = dirtyURL.URLStringValue.componentsSeparatedByString("?")[0].componentsSeparatedByString("#")[0]
+
+        if (dirtyURL.URLValue?.scheme == nil || dirtyURL.URLValue?.scheme == "" ) && self.defaultSchemeString != nil{
+            URLString = "\(self.defaultSchemeString!)://\(URLString)"
+        }
+
         URLString = self.replaceRegex(":/{3,}", "://", URLString)
         URLString = self.replaceRegex("(?<!:)/{2,}", "/", URLString)
         URLString = self.replaceRegex("/+$", "", URLString)

--- a/Sources/URLNavigator.swift
+++ b/Sources/URLNavigator.swift
@@ -135,14 +135,6 @@ public class URLNavigator {
 
             var values = [String: AnyObject]()
             
-            // Store any parameter from the URL's query
-            let urlComponents = NSURLComponents(string: URL.URLStringValue)
-            if let queryItems = urlComponents?.queryItems {
-                for var param:NSURLQueryItem in queryItems {
-                    values[param.name] = param.value
-                }
-            }
-
             // e.g. ["user", "<int:id>"]
             for (i, component) in URLPatternPathComponents.enumerate() {
                 guard i < URLPathComponents.count else {
@@ -162,6 +154,15 @@ public class URLNavigator {
                 }
             }
 
+            // Store any parameter from the URL's query
+            let urlComponents = NSURLComponents(string: URL.URLStringValue)
+            if let queryItems = urlComponents?.queryItems {
+                for param:NSURLQueryItem in queryItems {
+                    values[param.name] = param.value
+                }
+            }
+
+            
             return (URLPattern, values)
         }
         return nil

--- a/Sources/URLNavigator.swift
+++ b/Sources/URLNavigator.swift
@@ -134,6 +134,14 @@ public class URLNavigator {
             }
 
             var values = [String: AnyObject]()
+            
+            // Store any parameter from the URL's query
+            let urlComponents = NSURLComponents(string: URL.URLStringValue)
+            if let queryItems = urlComponents?.queryItems {
+                for var param:NSURLQueryItem in queryItems {
+                    values[param.name] = param.value
+                }
+            }
 
             // e.g. ["user", "<int:id>"]
             for (i, component) in URLPatternPathComponents.enumerate() {

--- a/Tests/URLNavigatorInternalTests.swift
+++ b/Tests/URLNavigatorInternalTests.swift
@@ -92,10 +92,12 @@ class URLNavigatorInternalTests: XCTestCase {
     }
 
     func testNormalizedURL() {
+        URLNavigator.defaultSchemeString = "myapp"
         XCTAssertEqual(URLNavigator.normalizedURL("myapp://user/<id>/hello").URLStringValue, "myapp://user/<id>/hello")
         XCTAssertEqual(URLNavigator.normalizedURL("myapp:///////user///<id>//hello/??/#abc=/def").URLStringValue,
             "myapp://user/<id>/hello")
         XCTAssertEqual(URLNavigator.normalizedURL("https://<path:_>").URLStringValue, "https://<path:_>")
+        XCTAssertEqual(URLNavigator.normalizedURL("/user").URLStringValue, "myapp://user")
     }
 
     func testPlaceholderValueFromURLPathComponents() {

--- a/Tests/URLNavigatorInternalTests.swift
+++ b/Tests/URLNavigatorInternalTests.swift
@@ -60,10 +60,16 @@ class URLNavigatorInternalTests: XCTestCase {
             XCTAssertEqual(values as! [String: String], ["id": "1", "object": "posts"])
         }();
         {
+            let from = ["myapp://user/<id>", "myapp://user/<id>/<object>"]
+            let (URLPattern, values) = URLNavigator.matchURL("myapp://user/1/posts?param1=value1", from: from)!
+            XCTAssertEqual(URLPattern, "myapp://user/<id>/<object>")
+            XCTAssertEqual(values as! [String: String], ["id": "1", "object": "posts","param1": "value1"])
+        }();
+        {
             let from = ["myapp://alert"]
             let (URLPattern, values) = URLNavigator.matchURL("myapp://alert?title=hello&message=world", from: from)!
             XCTAssertEqual(URLPattern, "myapp://alert")
-            XCTAssertEqual(values.count, 0)
+            XCTAssertEqual(values.count, 2)
         }();
         {
             let from = ["http://<path:url>"]
@@ -81,13 +87,13 @@ class URLNavigatorInternalTests: XCTestCase {
             let from = ["http://<path:url>"]
             let (URLPattern, values) = URLNavigator.matchURL("http://google.com/search?q=URLNavigator", from: from)!
             XCTAssertEqual(URLPattern, "http://<path:url>")
-            XCTAssertEqual(values as! [String: String], ["url": "google.com/search"])
+            XCTAssertEqual(values as! [String: String], ["url": "google.com/search", "q": "URLNavigator"])
         }();
         {
             let from = ["http://<path:url>"]
             let (URLPattern, values) = URLNavigator.matchURL("http://google.com/search/?q=URLNavigator", from: from)!
             XCTAssertEqual(URLPattern, "http://<path:url>")
-            XCTAssertEqual(values as! [String: String], ["url": "google.com/search"])
+            XCTAssertEqual(values as! [String: String], ["url": "google.com/search", "q": "URLNavigator"])
         }();
     }
 

--- a/Tests/URLNavigatorPublicTests.swift
+++ b/Tests/URLNavigatorPublicTests.swift
@@ -49,6 +49,11 @@ class URLNavigatorPublicTests: XCTestCase {
         XCTAssertNil(self.navigator.viewControllerForURL("myapp://post/"))
         XCTAssert(self.navigator.viewControllerForURL("myapp://post/123") is PostViewController)
         XCTAssert(self.navigator.viewControllerForURL("myapp://post/hello-world") is PostViewController)
+        
+        let pvc:PostViewController = self.navigator.viewControllerForURL("myapp://post/hello-world?param1=value1") as! PostViewController
+        XCTAssert(pvc.postTitle == "hello-world")
+        XCTAssert(pvc.queryParam == "value1")
+        
 
         XCTAssertNil(self.navigator.viewControllerForURL("http://"))
         XCTAssertNil(self.navigator.viewControllerForURL("https://"))
@@ -147,13 +152,16 @@ private class UserViewController: UIViewController, URLNavigable {
 private class PostViewController: UIViewController, URLNavigable {
 
     var postTitle: String?
+    var queryParam: String?
 
     convenience required init?(URL: URLConvertible, values: [String : AnyObject]) {
-        guard let title = values["title"] as? String else {
-            return nil
-        }
         self.init()
-        self.postTitle = title
+        if let title = values["title"] as? String  {
+            self.postTitle = title
+        }
+        if let param1 = values["param1"] as? String  {
+            self.queryParam = param1
+        }
     }
     
 }

--- a/Tests/URLNavigatorPublicTests.swift
+++ b/Tests/URLNavigatorPublicTests.swift
@@ -58,6 +58,21 @@ class URLNavigatorPublicTests: XCTestCase {
         XCTAssert(self.navigator.viewControllerForURL("http://google.com/search?q=URLNavigator") is WebViewController)
         XCTAssert(self.navigator.viewControllerForURL("http://google.com/search/?q=URLNavigator") is WebViewController)
     }
+    
+    func testDefaultScheme(){
+        URLNavigator.defaultSchemeString = "myapp"
+        
+        self.navigator.map("myapp://user/<int:id>", UserViewController.self)
+        self.navigator.map("/post/<title>", PostViewController.self)
+
+        XCTAssertNil(self.navigator.viewControllerForURL("invalid://user/1"))
+        XCTAssert(self.navigator.viewControllerForURL("myapp://user/1") is UserViewController)
+        XCTAssert(self.navigator.viewControllerForURL("/user/1") is UserViewController)
+
+        XCTAssert(self.navigator.viewControllerForURL("myapp://post/hello-world") is PostViewController)
+        XCTAssert(self.navigator.viewControllerForURL("/post/hello-world") is PostViewController)
+
+    }
 
     func testPushURL_URLNavigable() {
         self.navigator.map("myapp://user/<int:id>", UserViewController.self)


### PR DESCRIPTION
Hi,
I'm using URLNavigator, and I had two issues:
1) I found that write the scheme in every url is a little bit tedious. 
2) In my app I have different targets, with different schemes. So I had to create a method to change the scheme for every target

So I added a static var to parameterize the scheme, and use it in the method "normalizedURL" if the url don't have an scheme
I tried to add it as a property in the URLNavigator (I think that is a better option) , but I found that "normalizedURL" is a static method, so I had to make "defaultSchemeString" static to

What do you think about this change? and, What do you think about change the method "normalizedURL" from static to instance's method?


