### PR TITLE
Add support for setting navigator scheme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,32 @@ Navigator.openURL("myapp://post/12345")
 ```
 
 
+#### Setting Default Scheme
+
+Set `scheme` property on `URLNavigator` instance to get rid of schemes in every URLs.
+
+```swift
+Navigator.scheme = "myapp"
+Navigator.map("/user/<int:id>", UserViewController.self)
+Navigator.push("/user/10")
+```
+
+This is totally equivalent to:
+
+```swift
+Navigator.map("myapp://user/<int:id>", UserViewController.self)
+Navigator.push("myapp://user/10")
+```
+
+Setting `scheme` property will not affect other URLs that already have schemes.
+
+```swift
+Navigator.scheme = "myapp"
+Navigator.map("/user/<int:id>", UserViewController.self) // `myapp://user/<int:id>`
+Navigator.map("http://<path>", MyWebViewController.self) // `http://<path>`
+```
+
+
 License
 -------
 

--- a/Sources/URLNavigator.swift
+++ b/Sources/URLNavigator.swift
@@ -66,6 +66,24 @@ public class URLNavigator {
     /// A dictionary to store URLOpenHandlers by URL patterns.
     private(set) var URLOpenHandlers = [String: URLOpenHandler]()
 
+    /// A default scheme. If this value is set, it's available to map URL paths without schemes.
+    ///
+    ///     Navigator.scheme = "myapp"
+    ///     Navigator.map("/user/<int:id>", UserViewController.self)
+    ///     Navigator.map("/post/<title>", PostViewController.self)
+    ///
+    /// this is equivalent to:
+    ///
+    ///     Navigator.map("myapp://user/<int:id>", UserViewController.self)
+    ///     Navigator.map("myapp://post/<title>", PostViewController.self)
+    public var scheme: String? {
+        didSet {
+            if let scheme = self.scheme where scheme.containsString("://") == true {
+                self.scheme = scheme.componentsSeparatedByString("://")[0]
+            }
+        }
+    }
+
 
     // MARK: Initializing
 
@@ -91,13 +109,13 @@ public class URLNavigator {
 
     /// Map an `URLNavigable` to an URL pattern.
     public func map(URLPattern: URLConvertible, _ navigable: URLNavigable.Type) {
-        let URLString = URLNavigator.normalizedURL(URLPattern).URLStringValue
+        let URLString = URLNavigator.normalizedURL(URLPattern, scheme: self.scheme).URLStringValue
         self.URLMap[URLString] = navigable
     }
 
     /// Map an `URLOpenHandler` to an URL pattern.
     public func map(URLPattern: URLConvertible, _ handler: URLOpenHandler) {
-        let URLString = URLNavigator.normalizedURL(URLPattern).URLStringValue
+        let URLString = URLNavigator.normalizedURL(URLPattern, scheme: self.scheme).URLStringValue
         self.URLOpenHandlers[URLString] = handler
     }
 
@@ -118,9 +136,10 @@ public class URLNavigator {
     /// - Parameter from: The array of URL patterns.
     ///
     /// - Returns: A tuple of URL pattern string and a dictionary of URL placeholder values.
-    static func matchURL(URL: URLConvertible, from URLPatterns: [String]) -> (String, [String: AnyObject])? {
-        // e.g. ["myapp:", "user", "123"]
-        let URLPathComponents = URLNavigator.normalizedURL(URL).URLStringValue.componentsSeparatedByString("/")
+    static func matchURL(URL: URLConvertible, scheme: String? = nil,
+                         from URLPatterns: [String]) -> (String, [String: AnyObject])? {
+        let normalizedURLString = URLNavigator.normalizedURL(URL, scheme: scheme).URLStringValue
+        let URLPathComponents = normalizedURLString.componentsSeparatedByString("/") // e.g. ["myapp:", "user", "123"]
 
         outer: for URLPattern in URLPatterns {
             // e.g. ["myapp:", "user", "<int:id>"]
@@ -161,7 +180,7 @@ public class URLNavigator {
     /// - Parameter URL: The URL to find view controllers.
     /// - Returns: A match view controller or `nil` if not matched.
     public func viewControllerForURL(URL: URLConvertible) -> UIViewController? {
-        if let (URLPattern, values) = URLNavigator.matchURL(URL, from: Array(self.URLMap.keys)) {
+        if let (URLPattern, values) = URLNavigator.matchURL(URL, scheme: self.scheme, from: Array(self.URLMap.keys)) {
             let navigable = self.URLMap[URLPattern]
             return navigable?.init(URL: URL, values: values) as? UIViewController
         }
@@ -288,7 +307,8 @@ public class URLNavigator {
     ///
     /// - Returns: The return value of the matching `URLOpenHandler`. Returns `false` if there's no match.
     public func openURL(URL: URLConvertible) -> Bool {
-        if let (URLPattern, values) = URLNavigator.matchURL(URL, from: Array(self.URLOpenHandlers.keys)) {
+        let URLOpenHandlersKeys = Array(self.URLOpenHandlers.keys)
+        if let (URLPattern, values) = URLNavigator.matchURL(URL, scheme: self.scheme, from: URLOpenHandlersKeys) {
             let handler = self.URLOpenHandlers[URLPattern]
             if handler?(URL: URL, values: values) == true {
                 return true
@@ -300,6 +320,22 @@ public class URLNavigator {
 
     // MARK: Utils
 
+    /// Returns an scheme-appended `URLConvertible` if given `URL` doesn't have its scheme.
+    static func URLWithScheme(scheme: String?, _ URL: URLConvertible) -> URLConvertible {
+        let URLString = URL.URLStringValue
+        if let scheme = scheme where !URLString.containsString("://") {
+            #if DEBUG
+                if !URLPatternString.hasPrefix("/") {
+                    NSLog("[Warning] URL pattern doesn't have leading slash(/): '\(URL)'")
+                }
+            #endif
+            return scheme + ":/" + URLString
+        } else if scheme == nil && !URLString.containsString("://") {
+            assertionFailure("Either navigator or URL should have scheme: '\(URL)'") // assert only in debug build
+        }
+        return URLString
+    }
+
     /// Returns the URL by
     ///
     /// - Removing redundant trailing slash(/) on scheme
@@ -309,11 +345,12 @@ public class URLNavigator {
     /// - Parameter URL: The dirty URL to be normalized.
     ///
     /// - Returns: The normalized URL. Returns `nil` if the pecified URL is invalid.
-    static func normalizedURL(dirtyURL: URLConvertible) -> URLConvertible {
+    static func normalizedURL(dirtyURL: URLConvertible, scheme: String? = nil) -> URLConvertible {
         guard dirtyURL.URLValue != nil else {
             return dirtyURL
         }
-        var URLString = dirtyURL.URLStringValue.componentsSeparatedByString("?")[0].componentsSeparatedByString("#")[0]
+        var URLString = URLNavigator.URLWithScheme(scheme, dirtyURL).URLStringValue
+        URLString = URLString.componentsSeparatedByString("?")[0].componentsSeparatedByString("#")[0]
         URLString = self.replaceRegex(":/{3,}", "://", URLString)
         URLString = self.replaceRegex("(?<!:)/{2,}", "/", URLString)
         URLString = self.replaceRegex("/+$", "", URLString)

--- a/Tests/URLNavigatorInternalTests.swift
+++ b/Tests/URLNavigatorInternalTests.swift
@@ -36,59 +36,120 @@ class URLNavigatorInternalTests: XCTestCase {
             XCTAssertNil(URLNavigator.matchURL("myapp://user/1", from: ["myapp://user/<id>/hello"]))
         }();
         {
+            XCTAssertNil(URLNavigator.matchURL("/user/1", scheme: "myapp", from: []))
+        }();
+        {
+            XCTAssertNil(URLNavigator.matchURL("/user/1", scheme: "myapp", from: ["myapp://comment/<id>"]))
+        }();
+        {
+            XCTAssertNil(URLNavigator.matchURL("/user/1", scheme: "myapp", from: ["myapp://user/<id>/hello"]))
+        }();
+        {
+            XCTAssertNil(URLNavigator.matchURL("myapp://user/1", scheme: "myapp", from: []))
+        }();
+        {
+            XCTAssertNil(URLNavigator.matchURL("myapp://user/1", scheme: "myapp", from: ["myapp://comment/<id>"]))
+        }();
+        {
+            XCTAssertNil(URLNavigator.matchURL("myapp://user/1", scheme: "myapp", from: ["myapp://user/<id>/hello"]))
+        }();
+        {
             let from = ["myapp://hello"]
             let (URLPattern, values) = URLNavigator.matchURL("myapp://hello", from: from)!
             XCTAssertEqual(URLPattern, "myapp://hello")
             XCTAssertEqual(values.count, 0)
+
+            let scheme = URLNavigator.matchURL("/hello", scheme: "myapp", from: from)!
+            XCTAssertEqual(URLPattern, scheme.0)
+            XCTAssertEqual(values as! [String: String], scheme.1 as! [String: String])
         }();
         {
             let from = ["myapp://user/<id>"]
             let (URLPattern, values) = URLNavigator.matchURL("myapp://user/1", from: from)!
             XCTAssertEqual(URLPattern, "myapp://user/<id>")
             XCTAssertEqual(values as! [String: String], ["id": "1"])
+
+            let scheme = URLNavigator.matchURL("/user/1", scheme: "myapp", from: from)!
+            XCTAssertEqual(URLPattern, scheme.0)
+            XCTAssertEqual(values as! [String: String], scheme.1 as! [String: String])
         }();
         {
             let from = ["myapp://user/<id>", "myapp://user/<id>/hello"]
             let (URLPattern, values) = URLNavigator.matchURL("myapp://user/1", from: from)!
             XCTAssertEqual(URLPattern, "myapp://user/<id>")
             XCTAssertEqual(values as! [String: String], ["id": "1"])
+
+            let scheme = URLNavigator.matchURL("/user/1", scheme: "myapp", from: from)!
+            XCTAssertEqual(URLPattern, scheme.0)
+            XCTAssertEqual(values as! [String: String], scheme.1 as! [String: String])
         }();
         {
             let from = ["myapp://user/<id>", "myapp://user/<id>/<object>"]
             let (URLPattern, values) = URLNavigator.matchURL("myapp://user/1/posts", from: from)!
             XCTAssertEqual(URLPattern, "myapp://user/<id>/<object>")
             XCTAssertEqual(values as! [String: String], ["id": "1", "object": "posts"])
+
+            let scheme = URLNavigator.matchURL("/user/1/posts", scheme: "myapp", from: from)!
+            XCTAssertEqual(URLPattern, scheme.0)
+            XCTAssertEqual(values as! [String: String], scheme.1 as! [String: String])
         }();
         {
             let from = ["myapp://alert"]
             let (URLPattern, values) = URLNavigator.matchURL("myapp://alert?title=hello&message=world", from: from)!
             XCTAssertEqual(URLPattern, "myapp://alert")
             XCTAssertEqual(values.count, 0)
+
+            let scheme = URLNavigator.matchURL("/alert?title=hello&message=world", scheme: "myapp", from: from)!
+            XCTAssertEqual(URLPattern, scheme.0)
+            XCTAssertEqual(values as! [String: String], scheme.1 as! [String: String])
         }();
         {
             let from = ["http://<path:url>"]
             let (URLPattern, values) = URLNavigator.matchURL("http://xoul.kr", from: from)!
             XCTAssertEqual(URLPattern, "http://<path:url>")
             XCTAssertEqual(values as! [String: String], ["url": "xoul.kr"])
+
+            let scheme = URLNavigator.matchURL("http://xoul.kr", scheme: "myapp", from: from)!
+            XCTAssertEqual(URLPattern, scheme.0)
+            XCTAssertEqual(values as! [String: String], scheme.1 as! [String: String])
         }();
         {
             let from = ["http://<path:url>"]
             let (URLPattern, values) = URLNavigator.matchURL("http://xoul.kr/resume", from: from)!
             XCTAssertEqual(URLPattern, "http://<path:url>")
             XCTAssertEqual(values as! [String: String], ["url": "xoul.kr/resume"])
+
+            let scheme = URLNavigator.matchURL("http://xoul.kr/resume", scheme: "myapp", from: from)!
+            XCTAssertEqual(URLPattern, scheme.0)
+            XCTAssertEqual(values as! [String: String], scheme.1 as! [String: String])
         }();
         {
             let from = ["http://<path:url>"]
             let (URLPattern, values) = URLNavigator.matchURL("http://google.com/search?q=URLNavigator", from: from)!
             XCTAssertEqual(URLPattern, "http://<path:url>")
             XCTAssertEqual(values as! [String: String], ["url": "google.com/search"])
+
+            let scheme = URLNavigator.matchURL("http://google.com/search?q=URLNavigator", scheme: "myapp", from: from)!
+            XCTAssertEqual(URLPattern, scheme.0)
+            XCTAssertEqual(values as! [String: String], scheme.1 as! [String: String])
         }();
         {
             let from = ["http://<path:url>"]
             let (URLPattern, values) = URLNavigator.matchURL("http://google.com/search/?q=URLNavigator", from: from)!
             XCTAssertEqual(URLPattern, "http://<path:url>")
             XCTAssertEqual(values as! [String: String], ["url": "google.com/search"])
+
+            let scheme = URLNavigator.matchURL("http://google.com/search/?q=URLNavigator",
+                                               scheme: "myapp", from: from)!
+            XCTAssertEqual(URLPattern, scheme.0)
+            XCTAssertEqual(values as! [String: String], scheme.1 as! [String: String])
         }();
+    }
+
+    func testURLWithScheme() {
+        XCTAssertEqual(URLNavigator.URLWithScheme(nil, "myapp://user/1").URLStringValue, "myapp://user/1")
+        XCTAssertEqual(URLNavigator.URLWithScheme("myapp", "/user/1").URLStringValue, "myapp://user/1")
+        XCTAssertEqual(URLNavigator.URLWithScheme("", "/user/1").URLStringValue, "://user/1") // idiot
     }
 
     func testNormalizedURL() {


### PR DESCRIPTION
Another implementation for #10

```swift
Navigator.scheme = "myapp"
Navigator.map("/user/<int:id>", UserViewController.self)
Navigator.map("/alert") { _ in print("Alert") }

Navigator.push("/user/123")
Navigator.present("/user/123")
Navigator.open("/alert?title=Hi")
```

this is equivalent to:

```swift
Navigator.map("myapp://user/<int:id>", UserViewController.self)
Navigator.map("myapp://alert") { _ in print("Alert") }

Navigator.push("myapp://user/123")
Navigator.present("myapp://user/123")
Navigator.open("myapp://alert?title=Hi")
```

Example for multiple navigators:

```swift
let facebookNavigator = URLNavigator()
facebookNavigator.scheme = "fb"
facebookNavigator.map("/post/<id>", PostViewController.self) // "fb://post/<id>"

let instagramNavigator = URLNavigator()
instagramNavigator.scheme = "instagram"
instagramNavigator.map("/post/<id>", PostViewController.self) // "instagram://post/<id>"
```
