### PR TITLE
Add `queryParameters` and `queryItems ` property to `URLConvertible`

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Navigator.map("myapp://user/<int:id>", UserViewController.self)
 Navigator.map("myapp://post/<title>", PostViewController.self)
 
 Navigator.map("myapp://alert") { URL, values in
-    print(URL.parameters["title"])
-    print(URL.parameters["message"])
+    print(URL.queryParameters["title"])
+    print(URL.queryParameters["message"])
     return true
 }
 ```

--- a/Sources/URLConvertible.swift
+++ b/Sources/URLConvertible.swift
@@ -26,6 +26,39 @@ import Foundation
 public protocol URLConvertible {
     var URLValue: NSURL? { get }
     var URLStringValue: String { get }
+
+    /// Returns URL query parameters. For convenience, this property will never return `nil` even if there's no query
+    /// string in URL. This property doesn't take care of duplicated keys. Use `queryItems` for strictness.
+    ///
+    /// - SeeAlso: `queryItems`
+    var queryParameters: [String: String] { get }
+
+    /// Returns `queryItems` property of `NSURLComponents` instance.
+    ///
+    /// - SeeAlso: `queryParameters`
+    @available(iOS 8, *)
+    var queryItems: [NSURLQueryItem]? { get }
+}
+
+extension URLConvertible {
+    public var queryParameters: [String: String] {
+        var parameters = [String: String]()
+        self.URLValue?.query?.componentsSeparatedByString("&").forEach {
+            let keyAndValue = $0.componentsSeparatedByString("=")
+            if keyAndValue.count == 2 {
+                let key = keyAndValue[0]
+                let value = keyAndValue[1].stringByReplacingOccurrencesOfString("+", withString: " ")
+                                          .stringByRemovingPercentEncoding ?? keyAndValue[1]
+                parameters[key] = value
+            }
+        }
+        return parameters
+    }
+
+    @available(iOS 8, *)
+    public var queryItems: [NSURLQueryItem]? {
+        return NSURLComponents(string: self.URLStringValue)?.queryItems
+    }
 }
 
 extension String: URLConvertible {

--- a/Tests/URLConvertibleTests.swift
+++ b/Tests/URLConvertibleTests.swift
@@ -1,0 +1,41 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2016 Suyeol Jeon (xoul.kr)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import XCTest
+import URLNavigator
+
+class URLConvertibleTests: XCTestCase {
+
+    func testParameters() {
+        XCTAssertTrue("myapp://alert".queryParameters.isEmpty)
+        XCTAssertTrue("myapp://alert?".queryParameters.isEmpty)
+        XCTAssertTrue("myapp://alert?title".queryParameters.isEmpty)
+        XCTAssertEqual("myapp://alert?title=".queryParameters, ["title": ""])
+        XCTAssertEqual("myapp://alert?title=Hello+World!".queryParameters, ["title": "Hello World!"])
+        XCTAssertEqual("myapp://alert?title=Hello%20World!".queryParameters, ["title": "Hello World!"])
+        XCTAssertEqual("myapp://alert?title=Hello+World!&message=Nice+to+meet+you+:)".queryParameters,
+                       ["title": "Hello World!", "message": "Nice to meet you :)"])
+        XCTAssertEqual("myapp://alert?title=Hello%20World!&message=Nice%20to%20meet%20you%20:)".queryParameters,
+                       ["title": "Hello World!", "message": "Nice to meet you :)"])
+    }
+
+}

--- a/Tests/URLNavigatorPublicTests.swift
+++ b/Tests/URLNavigatorPublicTests.swift
@@ -39,6 +39,7 @@ class URLNavigatorPublicTests: XCTestCase {
     func testViewControllerForURL() {
         self.navigator.map("myapp://user/<int:id>", UserViewController.self)
         self.navigator.map("myapp://post/<title>", PostViewController.self)
+        self.navigator.map("myapp://search", SearchViewController.self)
         self.navigator.map("http://<path:_>", WebViewController.self)
         self.navigator.map("https://<path:_>", WebViewController.self)
 
@@ -49,6 +50,15 @@ class URLNavigatorPublicTests: XCTestCase {
         XCTAssertNil(self.navigator.viewControllerForURL("myapp://post/"))
         XCTAssert(self.navigator.viewControllerForURL("myapp://post/123") is PostViewController)
         XCTAssert(self.navigator.viewControllerForURL("myapp://post/hello-world") is PostViewController)
+
+        XCTAssertNil(self.navigator.viewControllerForURL("myapp://search"))
+        XCTAssertNil(self.navigator.viewControllerForURL("myapp://search?"))
+        XCTAssertNil(self.navigator.viewControllerForURL("myapp://search?query"))
+        XCTAssert(self.navigator.viewControllerForURL("myapp://search?query=") is SearchViewController)
+        XCTAssertEqual(
+            (self.navigator.viewControllerForURL("myapp://search?query=Hello") as! SearchViewController).query,
+            "Hello"
+        )
 
         XCTAssertNil(self.navigator.viewControllerForURL("http://"))
         XCTAssertNil(self.navigator.viewControllerForURL("https://"))
@@ -251,6 +261,28 @@ private class WebViewController: UIViewController, URLNavigable {
     convenience required init?(URL: URLConvertible, values: [String : AnyObject]) {
         self.init()
         self.URL = URL
+    }
+
+}
+
+private class SearchViewController: UIViewController, URLNavigable {
+
+    let query: String
+
+    init(query: String) {
+        self.query = query
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    convenience required init?(URL: URLConvertible, values: [String: AnyObject]) {
+        guard let query = URL.queryParameters["query"] else {
+            return nil
+        }
+        self.init(query: query)
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
 
 }

--- a/URLNavigator.xcodeproj/project.pbxproj
+++ b/URLNavigator.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		03032BB81CCBA94B00F7EBFD /* URLConvertibleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03032BB61CCBA93400F7EBFD /* URLConvertibleTests.swift */; };
 		03107EDD1C6364E700DF2F14 /* URLNavigator.h in Headers */ = {isa = PBXBuildFile; fileRef = 03107EDA1C6364E700DF2F14 /* URLNavigator.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		03107EE01C63653900DF2F14 /* URLNavigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03107EDF1C63653900DF2F14 /* URLNavigator.swift */; };
 		03107EE21C6365BF00DF2F14 /* URLNavigable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03107EE11C6365BF00DF2F14 /* URLNavigable.swift */; };
@@ -28,6 +29,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		03032BB61CCBA93400F7EBFD /* URLConvertibleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLConvertibleTests.swift; sourceTree = "<group>"; };
 		03107ECE1C6362E800DF2F14 /* URLNavigator.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = URLNavigator.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		03107EDA1C6364E700DF2F14 /* URLNavigator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = URLNavigator.h; sourceTree = "<group>"; };
 		03107EDC1C6364E700DF2F14 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -103,6 +105,7 @@
 			children = (
 				03107EF71C636A5500DF2F14 /* URLNavigatorInternalTests.swift */,
 				03107EFA1C67288400DF2F14 /* URLNavigatorPublicTests.swift */,
+				03032BB61CCBA93400F7EBFD /* URLConvertibleTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -228,6 +231,7 @@
 			files = (
 				03107EF91C636A7500DF2F14 /* URLNavigatorInternalTests.swift in Sources */,
 				03107EFC1C67289100DF2F14 /* URLNavigatorPublicTests.swift in Sources */,
+				03032BB81CCBA94B00F7EBFD /* URLConvertibleTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
`URLConvertible` now has `queryParameters` and `queryItems`:

- **`queryParameters: [String: String]`**

    > Returns URL query parameters. For convenience, this property will never return `nil` even if there's no query string in URL. This property doesn't take care of duplicated keys. Use `queryItems` for strictness.

- **`queryItems: [NSURLQueryItem]?`**

    > Returns `queryItems` property of `NSURLComponents` instance.

This is another implementation for #12.
