### PR TITLE
Add NavigableFactory methods, and map Factory instead of Navigables

### DIFF
--- a/Sources/URLNavigableFactory.swift
+++ b/Sources/URLNavigableFactory.swift
@@ -1,0 +1,66 @@
+//
+//  URLNavigableFactory.swift
+//  URLNavigator
+//
+//  Created by Juan Cruz Ghigliani on 24/4/16.
+//  Copyright © 2016. All rights reserved.
+//
+
+import Foundation
+
+public class URLNavigableFactory{
+    func navigableInstance() -> URLNavigable{
+        return self.navigableInstance("", values: [:])
+    }
+    
+    func navigableInstance(URL: URLConvertible, values: [String: AnyObject]) -> URLNavigable{
+        fatalError("navigableInstance(URL:values:) has not been implemented")
+    }
+}
+
+public class URLNavigableWithClass:URLNavigableFactory{
+    var navigable:URLNavigable.Type
+    
+    public init (_ navigable:URLNavigable.Type){
+        self.navigable = navigable
+    }
+    
+    override func navigableInstance(URL: URLConvertible, values: [String: AnyObject]) -> URLNavigable{
+        return navigable.init(URL: URL, values: values)!
+    }
+
+}
+
+public class URLNavigableWithStoryboard:URLNavigableFactory{
+    var storyboard:String
+    var identifier:String
+    var bundle:NSBundle?
+    
+
+    public init (_  storyboard:String, identifier:String, bundle:NSBundle? = nil){
+        self.storyboard = storyboard
+        self.identifier = identifier
+        self.bundle = bundle
+    }
+
+    override func navigableInstance(URL: URLConvertible, values: [String: AnyObject]) -> URLNavigable{
+        return UIStoryboard(name: self.storyboard, bundle: self.bundle).instantiateViewControllerWithIdentifier(self.identifier) as! URLNavigable
+    }
+    
+}
+
+public class URLNavigableWithBlock:URLNavigableFactory{
+    public typealias factoryBlockType = (URL: URLConvertible, values: [String: AnyObject]) -> URLNavigable
+
+    var factoryBlock:factoryBlockType
+    
+    
+    public init (_ block:factoryBlockType){
+        self.factoryBlock = block
+    }
+    
+    override func navigableInstance(URL: URLConvertible, values: [String: AnyObject]) -> URLNavigable{
+        return self.factoryBlock(URL: URL, values: values)
+    }
+    
+}

--- a/Sources/URLNavigableFactory.swift
+++ b/Sources/URLNavigableFactory.swift
@@ -9,11 +9,11 @@
 import Foundation
 
 public class URLNavigableFactory{
-    func navigableInstance() -> URLNavigable{
+    func navigableInstance() -> URLNavigable?{
         return self.navigableInstance("", values: [:])
     }
     
-    func navigableInstance(URL: URLConvertible, values: [String: AnyObject]) -> URLNavigable{
+    func navigableInstance(URL: URLConvertible, values: [String: AnyObject]) -> URLNavigable?{
         fatalError("navigableInstance(URL:values:) has not been implemented")
     }
 }
@@ -25,8 +25,8 @@ public class URLNavigableWithClass:URLNavigableFactory{
         self.navigable = navigable
     }
     
-    override func navigableInstance(URL: URLConvertible, values: [String: AnyObject]) -> URLNavigable{
-        return navigable.init(URL: URL, values: values)!
+    override func navigableInstance(URL: URLConvertible, values: [String: AnyObject]) -> URLNavigable?{
+        return navigable.init(URL: URL, values: values)
     }
 
 }
@@ -43,14 +43,14 @@ public class URLNavigableWithStoryboard:URLNavigableFactory{
         self.bundle = bundle
     }
 
-    override func navigableInstance(URL: URLConvertible, values: [String: AnyObject]) -> URLNavigable{
-        return UIStoryboard(name: self.storyboard, bundle: self.bundle).instantiateViewControllerWithIdentifier(self.identifier) as! URLNavigable
+    override func navigableInstance(URL: URLConvertible, values: [String: AnyObject]) -> URLNavigable?{
+        return UIStoryboard(name: self.storyboard, bundle: self.bundle).instantiateViewControllerWithIdentifier(self.identifier) as? URLNavigable
     }
     
 }
 
 public class URLNavigableWithBlock:URLNavigableFactory{
-    public typealias factoryBlockType = (URL: URLConvertible, values: [String: AnyObject]) -> URLNavigable
+    public typealias factoryBlockType = (URL: URLConvertible, values: [String: AnyObject]) -> URLNavigable?
 
     var factoryBlock:factoryBlockType
     
@@ -59,7 +59,7 @@ public class URLNavigableWithBlock:URLNavigableFactory{
         self.factoryBlock = block
     }
     
-    override func navigableInstance(URL: URLConvertible, values: [String: AnyObject]) -> URLNavigable{
+    override func navigableInstance(URL: URLConvertible, values: [String: AnyObject]) -> URLNavigable?{
         return self.factoryBlock(URL: URL, values: values)
     }
     

--- a/Tests/TestingStoryboard.storyboard
+++ b/Tests/TestingStoryboard.storyboard
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10116" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+    </dependencies>
+    <scenes>
+        <!--User View Controller-->
+        <scene sceneID="ECl-a0-tFo">
+            <objects>
+                <viewController storyboardIdentifier="StoryboardIdentifier" id="Jzl-Q3-Fpc" customClass="UserViewController" customModule="URLNavigatorTests" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="yXo-2j-QK9"/>
+                        <viewControllerLayoutGuide type="bottom" id="WNm-pU-fPk"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="0xo-IK-wzc">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="sPk-hP-sVU" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="499" y="215"/>
+        </scene>
+    </scenes>
+</document>

--- a/Tests/URLNavigatorPublicTests.swift
+++ b/Tests/URLNavigatorPublicTests.swift
@@ -21,7 +21,7 @@
 // SOFTWARE.
 
 import XCTest
-import URLNavigator
+@testable import URLNavigator
 
 class URLNavigatorPublicTests: XCTestCase {
 
@@ -94,14 +94,14 @@ class URLNavigatorPublicTests: XCTestCase {
         
         /// Block Factory
         
-        self.navigator.map("myapp://user/<int:id>", URLNavigableWithBlock{ URL, values -> URLNavigable in
-            return UserViewController(URL:URL, values:values)!
+        self.navigator.map("myapp://user/<int:id>", URLNavigableWithBlock{ URL, values -> URLNavigable? in
+            return UserViewController(URL:URL, values:values)
             })
         XCTAssertNil(self.navigator.viewControllerForURL("myapp://user/awesome"))
         XCTAssert(self.navigator.viewControllerForURL("myapp://user/1") is UserViewController)
 
-        self.navigator.map("myapp://user/<int:id>"){ URL, values -> URLNavigable in
-            return UserViewController(URL:URL, values:values)!
+        self.navigator.map("myapp://user/<int:id>"){ URL, values -> URLNavigable? in
+            return UserViewController(URL:URL, values:values)
         }
         XCTAssertNil(self.navigator.viewControllerForURL("myapp://user/awesome"))
         XCTAssert(self.navigator.viewControllerForURL("myapp://user/1") is UserViewController)

--- a/Tests/URLNavigatorPublicTests.swift
+++ b/Tests/URLNavigatorPublicTests.swift
@@ -58,6 +58,46 @@ class URLNavigatorPublicTests: XCTestCase {
         XCTAssert(self.navigator.viewControllerForURL("http://google.com/search?q=URLNavigator") is WebViewController)
         XCTAssert(self.navigator.viewControllerForURL("http://google.com/search/?q=URLNavigator") is WebViewController)
     }
+    
+    func testViewControllerForURLWithViewFactory() {
+        /// Class Factory
+
+        self.navigator.map("myapp://user/<int:id>", URLNavigableWithClass(UserViewController.self))
+        XCTAssert(self.navigator.viewControllerForURL("myapp://user/1") is UserViewController)
+
+        
+        self.navigator.map("myapp://user/<int:id>", UserViewController.self)
+        XCTAssert(self.navigator.viewControllerForURL("myapp://user/1") is UserViewController)
+
+        
+        /// Storyboard Factory
+        
+        self.navigator.map("myapp://user/<int:id>", URLNavigableWithStoryboard("TestingStoryboard", identifier: "StoryboardIdentifier", bundle:NSBundle(forClass: self.dynamicType)))
+        XCTAssertNotNil(self.navigator.viewControllerForURL("myapp://user/1"))
+        XCTAssert(self.navigator.viewControllerForURL("myapp://user/1") is UserViewController)
+        
+        
+        
+        self.navigator.map("myapp://user/<int:id>", storyboard: "TestingStoryboard", identifier: "StoryboardIdentifier", bundle:NSBundle(forClass: self.dynamicType))
+        XCTAssert(self.navigator.viewControllerForURL("myapp://user/1") is UserViewController)
+
+        
+        /// Block Factory
+        
+        self.navigator.map("myapp://user/<int:id>", URLNavigableWithBlock{ URL, values -> URLNavigable in
+            return UserViewController(URL:URL, values:values)!
+            })
+        XCTAssertNil(self.navigator.viewControllerForURL("myapp://user/awesome"))
+        XCTAssert(self.navigator.viewControllerForURL("myapp://user/1") is UserViewController)
+
+        self.navigator.map("myapp://user/<int:id>"){ URL, values -> URLNavigable in
+            return UserViewController(URL:URL, values:values)!
+        }
+        XCTAssertNil(self.navigator.viewControllerForURL("myapp://user/awesome"))
+        XCTAssert(self.navigator.viewControllerForURL("myapp://user/1") is UserViewController)
+
+        
+    }
 
     func testPushURL_URLNavigable() {
         self.navigator.map("myapp://user/<int:id>", UserViewController.self)
@@ -99,7 +139,7 @@ class URLNavigatorPublicTests: XCTestCase {
     }
 
     func testOpenURL_URLOpenHandler() {
-        self.navigator.map("myapp://ping") { URL, values in
+        self.navigator.map("myapp://ping") { URL, values -> Bool in
             NSNotificationCenter.defaultCenter().postNotificationName("Ping", object: nil, userInfo: nil)
             return true
         }
@@ -199,7 +239,7 @@ class URLNavigatorPublicTests: XCTestCase {
 
     func testSchemeOpenURL_URLOpenHandler() {
         self.navigator.scheme = "myapp"
-        self.navigator.map("/ping") { URL, values in
+        self.navigator.map("/ping") { URL, values  -> Bool in
             NSNotificationCenter.defaultCenter().postNotificationName("Ping", object: nil, userInfo: nil)
             return true
         }
@@ -216,11 +256,11 @@ class URLNavigatorPublicTests: XCTestCase {
 
 }
 
-private class UserViewController: UIViewController, URLNavigable {
+public class UserViewController: UIViewController, URLNavigable {
 
     var userID: Int?
 
-    convenience required init?(URL: URLConvertible, values: [String : AnyObject]) {
+    convenience required public init?(URL: URLConvertible, values: [String : AnyObject]) {
         guard let id = values["id"] as? Int else {
             return nil
         }

--- a/URLNavigator.xcodeproj/project.pbxproj
+++ b/URLNavigator.xcodeproj/project.pbxproj
@@ -15,6 +15,9 @@
 		03107EF01C636A3D00DF2F14 /* URLNavigator.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 03107ECE1C6362E800DF2F14 /* URLNavigator.framework */; };
 		03107EF91C636A7500DF2F14 /* URLNavigatorInternalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03107EF71C636A5500DF2F14 /* URLNavigatorInternalTests.swift */; };
 		03107EFC1C67289100DF2F14 /* URLNavigatorPublicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03107EFA1C67288400DF2F14 /* URLNavigatorPublicTests.swift */; };
+		EE513F0D1CCCFEEB0056575F /* URLNavigableFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE513F0C1CCCFEEB0056575F /* URLNavigableFactory.swift */; };
+		EE513F121CCD47730056575F /* TestingStoryboard.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = EE513F111CCD47730056575F /* TestingStoryboard.storyboard */; };
+		EE513F131CCD47730056575F /* TestingStoryboard.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = EE513F111CCD47730056575F /* TestingStoryboard.storyboard */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -38,6 +41,8 @@
 		03107EEB1C636A3D00DF2F14 /* URLNavigatorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = URLNavigatorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		03107EF71C636A5500DF2F14 /* URLNavigatorInternalTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLNavigatorInternalTests.swift; sourceTree = "<group>"; };
 		03107EFA1C67288400DF2F14 /* URLNavigatorPublicTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLNavigatorPublicTests.swift; sourceTree = "<group>"; };
+		EE513F0C1CCCFEEB0056575F /* URLNavigableFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLNavigableFactory.swift; sourceTree = "<group>"; };
+		EE513F111CCD47730056575F /* TestingStoryboard.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = TestingStoryboard.storyboard; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -86,6 +91,7 @@
 				03107EE11C6365BF00DF2F14 /* URLNavigable.swift */,
 				03107EE31C6365E500DF2F14 /* URLConvertible.swift */,
 				03107EE51C6366F500DF2F14 /* UIViewController+TopMostViewController.swift */,
+				EE513F0C1CCCFEEB0056575F /* URLNavigableFactory.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -103,6 +109,7 @@
 			children = (
 				03107EF71C636A5500DF2F14 /* URLNavigatorInternalTests.swift */,
 				03107EFA1C67288400DF2F14 /* URLNavigatorPublicTests.swift */,
+				EE513F111CCD47730056575F /* TestingStoryboard.storyboard */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -198,6 +205,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EE513F121CCD47730056575F /* TestingStoryboard.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -205,6 +213,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EE513F131CCD47730056575F /* TestingStoryboard.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -217,6 +226,7 @@
 			files = (
 				03107EE61C6366F500DF2F14 /* UIViewController+TopMostViewController.swift in Sources */,
 				03107EE01C63653900DF2F14 /* URLNavigator.swift in Sources */,
+				EE513F0D1CCCFEEB0056575F /* URLNavigableFactory.swift in Sources */,
 				03107EE41C6365E500DF2F14 /* URLConvertible.swift in Sources */,
 				03107EE21C6365BF00DF2F14 /* URLNavigable.swift in Sources */,
 			);


### PR DESCRIPTION
Hi,
I created this PR only as a reference to show you some Idea that I had to improve the ViewControllers.
The main idea is map a factory class, instead a URLNavigable.Type , This  allow the user to have different methods to build URLNavigable instances. For example I created this 3:

1) URLNavigableWithClass: Use a URLNavigable.Type to create an instance

``` swift
self.navigator.map("myapp://user/<int:id>", URLNavigableWithClass(UserViewController.self))
```

2) URLNavigableWithStoryboard: Use a storyboard identifier to create the  URLNavigable instance

``` swift
self.navigator.map("myapp://user/<int:id>", URLNavigableWithStoryboard("TestingStoryboard", identifier: "StoryboardIdentifier"))
```

3) URLNavigableWithBlock: Use a block that return a URLNavigable instance

``` swift
self.navigator.map("myapp://user/<int:id>", URLNavigableWithBlock{ URL, values -> URLNavigable in
             // Complex UI Building
            return UserViewController(URL:URL, values:values)!
})
```

Also I created some convenience method to map the URL's with the factory

``` swift
self.navigator.map("myapp://user/<int:id>", URLNavigableWithClass(UserViewController.self))

self.navigator.map("myapp://user/<int:id>", UserViewController.self)
```

``` swift
self.navigator.map("myapp://user/<int:id>", URLNavigableWithStoryboard("TestingStoryboard", identifier: "StoryboardIdentifier"))

self.navigator.map("myapp://user/<int:id>", storyboard: "TestingStoryboard", identifier: "StoryboardIdentifier")
```

``` swift

self.navigator.map("myapp://user/<int:id>", URLNavigableWithBlock{ URL, values -> URLNavigable in
            return UserViewController(URL:URL, values:values)!
})

self.navigator.map("myapp://user/<int:id>"){ URL, values -> URLNavigable in
            // Complex UI Building
            return UserViewController(URL:URL, values:values)!
}
```

What do you think?

Juan C.
