### PR TITLE
add URLMaphandler for map UIViewcontroller by handler, which is useful for storyboard

### DIFF
--- a/Tests/URLNavigatorPublicTests.swift
+++ b/Tests/URLNavigatorPublicTests.swift
@@ -109,7 +109,7 @@ class URLNavigatorPublicTests: XCTestCase {
     }
 
     func testOpenURL_URLOpenHandler() {
-        self.navigator.map("myapp://ping") { URL, values in
+        self.navigator.map("myapp://ping") { (URL, values) -> Bool in
             NSNotificationCenter.defaultCenter().postNotificationName("Ping", object: nil, userInfo: nil)
             return true
         }
@@ -209,7 +209,7 @@ class URLNavigatorPublicTests: XCTestCase {
 
     func testSchemeOpenURL_URLOpenHandler() {
         self.navigator.scheme = "myapp"
-        self.navigator.map("/ping") { URL, values in
+        self.navigator.map("/ping") { (URL, values) -> Bool in
             NSNotificationCenter.defaultCenter().postNotificationName("Ping", object: nil, userInfo: nil)
             return true
         }


### PR DESCRIPTION
I add URLMaphandler for map UIViewcontroller by handler, which is useful for storyboard.

Sometimes, i want to user `URLNavigator.viewControllerForURL` to find my UIViewController, but it is implement in Storyboard , result in  i can't use `URLNavigator.map`.

with this, could use

```
Navigator.map("scheme://host") { (URL, values) -> UIViewController? in
            let storyBoard = UIStoryboard(name: "StoryboardName", bundle: bundle)
            let controller =  storyBoard.instantiateViewControllerWithIdentifier("Identifier")
         ///   do some settings
           return controller
        }
```

then use like URLMap

```
let controller = Navigator.viewControllerForURL("scheme://host")
```
