### PR TITLE
Return query items in URLOpenHandler

### DIFF
--- a/Example/Sources/Navigator/NavigationMap.swift
+++ b/Example/Sources/Navigator/NavigationMap.swift
@@ -19,7 +19,7 @@ struct NavigationMap {
         Navigator.map("navigator://alert", self.alert)
     }
 
-    private static func alert(URL: URLConvertible, values: [String: AnyObject]) -> Bool {
+    private static func alert(URL: URLConvertible, values: [String: AnyObject], queryItems: [NSURLQueryItem]) -> Bool {
         let title = URL.queryParameters["title"]
         let message = URL.queryParameters["message"]
         let alertController = UIAlertController(title: title, message: message, preferredStyle: .Alert)

--- a/Sources/URLMatcher.swift
+++ b/Sources/URLMatcher.swift
@@ -34,7 +34,7 @@ import Foundation
 public struct URLMatchComponents {
     let pattern: String
     let values: [String : AnyObject]
-    let queryItems: [String : AnyObject]
+    let queryItems: [NSURLQueryItem]
 }
 
 /// URLMatcher provides a way to match URLs against a list of specified patterns.
@@ -93,14 +93,10 @@ public class URLMatcher {
             }
             
             var values = [String: AnyObject]()
-            var queryItems = [String: AnyObject]()
             
             // Query String
             let urlComponents = NSURLComponents(string: URL.URLStringValue)
-            
-            for queryItem in urlComponents?.queryItems ?? [] {
-                queryItems[queryItem.name] = queryItem.value
-            }
+            let queryItems: [NSURLQueryItem] = urlComponents?.queryItems ?? []
             
             // e.g. ["user", "<int:id>"]
             for (i, component) in URLPatternPathComponents.enumerate() {

--- a/Sources/URLNavigator.swift
+++ b/Sources/URLNavigator.swift
@@ -58,7 +58,7 @@ import UIKit
 public class URLNavigator {
 
     /// A closure type which has URL and values for parameters.
-    public typealias URLOpenHandler = (URL: URLConvertible, values: [String: AnyObject]) -> Bool
+    public typealias URLOpenHandler = (URL: URLConvertible, values: [String: AnyObject], queryItems: [NSURLQueryItem]) -> Bool
 
     /// A dictionary to store URLNaviables by URL patterns.
     private(set) var URLMap = [String: URLNavigable.Type]()
@@ -253,7 +253,7 @@ public class URLNavigator {
         let URLOpenHandlersKeys = Array(self.URLOpenHandlers.keys)
         if let urlMatchComponents = URLMatcher.defaultMatcher().matchURL(URL, scheme: self.scheme, from: URLOpenHandlersKeys) {
             let handler = self.URLOpenHandlers[urlMatchComponents.pattern]
-            if handler?(URL: URL, values: urlMatchComponents.values) == true {
+            if handler?(URL: URL, values: urlMatchComponents.values, queryItems: urlMatchComponents.queryItems) == true {
                 return true
             }
         }

--- a/Tests/URLMatcherPublicTests.swift
+++ b/Tests/URLMatcherPublicTests.swift
@@ -98,22 +98,24 @@ class URLMatcherPublicTests: XCTestCase {
             let urlMatchComponents = matcher.matchURL("myapp://user/1/posts", from: from)!
             XCTAssertEqual(urlMatchComponents.pattern, "myapp://user/<id>/<object>")
             XCTAssertEqual(urlMatchComponents.values as! [String: String], ["id": "1", "object": "posts"])
+            XCTAssertEqual(urlMatchComponents.queryItems, [])
             
             let scheme = matcher.matchURL("/user/1/posts", scheme: "myapp", from: from)!
             XCTAssertEqual(urlMatchComponents.pattern, scheme.pattern)
             XCTAssertEqual(urlMatchComponents.values as! [String: String], scheme.values as! [String: String])
+            XCTAssertEqual(urlMatchComponents.queryItems, scheme.queryItems)
         }();
         {
             let from = ["myapp://alert"]
             let urlMatchComponents = matcher.matchURL("myapp://alert?title=hello&message=world", from: from)!
             XCTAssertEqual(urlMatchComponents.pattern, "myapp://alert")
             XCTAssertEqual(urlMatchComponents.values.count, 0)
-            XCTAssertEqual(urlMatchComponents.queryItems as! [String: String], ["title": "hello", "message": "world"])
+            XCTAssertEqual(urlMatchComponents.queryItems, [NSURLQueryItem(name:"title", value: "hello"), NSURLQueryItem(name: "message", value: "world")])
             
             let scheme = matcher.matchURL("/alert?title=hello&message=world", scheme: "myapp", from: from)!
             XCTAssertEqual(urlMatchComponents.pattern, scheme.pattern)
             XCTAssertEqual(urlMatchComponents.values as! [String: String], scheme.values as! [String: String])
-            XCTAssertEqual(urlMatchComponents.queryItems as! [String: String], ["title": "hello", "message": "world"])
+            XCTAssertEqual(urlMatchComponents.queryItems, [NSURLQueryItem(name:"title", value: "hello"), NSURLQueryItem(name: "message", value: "world")])
         }();
         {
             let from = ["http://<path:url>"]
@@ -140,25 +142,38 @@ class URLMatcherPublicTests: XCTestCase {
             let urlMatchComponents = matcher.matchURL("http://google.com/search?q=URLNavigator", from: from)!
             XCTAssertEqual(urlMatchComponents.pattern, "http://<path:url>")
             XCTAssertEqual(urlMatchComponents.values as! [String: String], ["url": "google.com/search"])
-            XCTAssertEqual(urlMatchComponents.queryItems as! [String: String], ["q": "URLNavigator"])
+            XCTAssertEqual(urlMatchComponents.queryItems, [NSURLQueryItem(name: "q", value: "URLNavigator")])
             
             let scheme = matcher.matchURL("http://google.com/search?q=URLNavigator", scheme: "myapp", from: from)!
             XCTAssertEqual(urlMatchComponents.pattern, scheme.pattern)
             XCTAssertEqual(urlMatchComponents.values as! [String: String], scheme.values as! [String: String])
-            XCTAssertEqual(urlMatchComponents.queryItems as! [String: String], scheme.queryItems as! [String: String])
+            XCTAssertEqual(urlMatchComponents.queryItems, scheme.queryItems)
         }();
         {
             let from = ["http://<path:url>"]
             let urlMatchComponents = matcher.matchURL("http://google.com/search/?q=URLNavigator", from: from)!
             XCTAssertEqual(urlMatchComponents.pattern, "http://<path:url>")
             XCTAssertEqual(urlMatchComponents.values as! [String: String], ["url": "google.com/search"])
-            XCTAssertEqual(urlMatchComponents.queryItems as! [String: String], ["q": "URLNavigator"])
+            XCTAssertEqual(urlMatchComponents.queryItems, [NSURLQueryItem(name: "q", value: "URLNavigator")])
             
             let scheme = matcher.matchURL("http://google.com/search/?q=URLNavigator",
                                           scheme: "myapp", from: from)!
             XCTAssertEqual(urlMatchComponents.pattern, scheme.pattern)
             XCTAssertEqual(urlMatchComponents.values as! [String: String], scheme.values as! [String: String])
-            XCTAssertEqual(urlMatchComponents.queryItems as! [String: String], scheme.queryItems as! [String: String])
+            XCTAssertEqual(urlMatchComponents.queryItems, scheme.queryItems)
+        }();
+        {
+            let from = ["http://google.com/users/<string:user_id>"]
+            let urlMatchComponents = matcher.matchURL("http://google.com/users/abcd1234?picture=large&name=middle", from: from)!
+            XCTAssertEqual(urlMatchComponents.pattern, "http://google.com/users/<string:user_id>")
+            XCTAssertEqual(urlMatchComponents.values as! [String: String], ["user_id": "abcd1234"])
+            XCTAssertEqual(urlMatchComponents.queryItems, [NSURLQueryItem(name: "picture", value: "large"), NSURLQueryItem(name: "name", value: "middle")])
+            
+            let scheme = matcher.matchURL("http://google.com/users/abcd1234?picture=large&name=middle",
+                                          scheme: "myapp", from: from)!
+            XCTAssertEqual(urlMatchComponents.pattern, scheme.pattern)
+            XCTAssertEqual(urlMatchComponents.values as! [String: String], scheme.values as! [String: String])
+            XCTAssertEqual(urlMatchComponents.queryItems, scheme.queryItems)
         }();
     }
 }

--- a/Tests/URLNavigatorPublicTests.swift
+++ b/Tests/URLNavigatorPublicTests.swift
@@ -109,7 +109,7 @@ class URLNavigatorPublicTests: XCTestCase {
     }
 
     func testOpenURL_URLOpenHandler() {
-        self.navigator.map("myapp://ping") { URL, values in
+        self.navigator.map("myapp://ping") { URL, values, queryItems in
             NSNotificationCenter.defaultCenter().postNotificationName("Ping", object: nil, userInfo: nil)
             return true
         }
@@ -209,7 +209,7 @@ class URLNavigatorPublicTests: XCTestCase {
 
     func testSchemeOpenURL_URLOpenHandler() {
         self.navigator.scheme = "myapp"
-        self.navigator.map("/ping") { URL, values in
+        self.navigator.map("/ping") { URL, values, queryItems in
             NSNotificationCenter.defaultCenter().postNotificationName("Ping", object: nil, userInfo: nil)
             return true
         }


### PR DESCRIPTION
This PR returns the URL query items as part of the `URLOpenHandler` type.

Previously, they were not being returned at all since they are separate from `values` inside `URLMatcher.matchURL(_:scheme:from:)`. Additionally, this changes the `URLMatchComponents.queryItems` type from `[String : AnyObject]` to `[NSURLQueryItem]`.