### PR TITLE
Remove `queryItems` from `URLMatchComponents`

### DIFF
--- a/Sources/URLMatcher.swift
+++ b/Sources/URLMatcher.swift
@@ -30,11 +30,9 @@ import Foundation
 /// It contains the following attributes:
 ///     - pattern: The URL pattern that was matched.
 ///     - values: The values extracted from the URL.
-///     - queryItems: The query items of the URL.
 public struct URLMatchComponents {
     let pattern: String
     let values: [String : AnyObject]
-    let queryItems: [String : AnyObject]
 }
 
 /// URLMatcher provides a way to match URLs against a list of specified patterns.
@@ -93,14 +91,6 @@ public class URLMatcher {
             }
             
             var values = [String: AnyObject]()
-            var queryItems = [String: AnyObject]()
-            
-            // Query String
-            let urlComponents = NSURLComponents(string: URL.URLStringValue)
-            
-            for queryItem in urlComponents?.queryItems ?? [] {
-                queryItems[queryItem.name] = queryItem.value
-            }
             
             // e.g. ["user", "<int:id>"]
             for (i, component) in URLPatternPathComponents.enumerate() {
@@ -121,7 +111,7 @@ public class URLMatcher {
                 }
             }
             
-            return URLMatchComponents(pattern: URLPattern, values: values, queryItems: queryItems)
+            return URLMatchComponents(pattern: URLPattern, values: values)
         }
         return nil
     }

--- a/Tests/URLMatcherPublicTests.swift
+++ b/Tests/URLMatcherPublicTests.swift
@@ -108,12 +108,10 @@ class URLMatcherPublicTests: XCTestCase {
             let urlMatchComponents = matcher.matchURL("myapp://alert?title=hello&message=world", from: from)!
             XCTAssertEqual(urlMatchComponents.pattern, "myapp://alert")
             XCTAssertEqual(urlMatchComponents.values.count, 0)
-            XCTAssertEqual(urlMatchComponents.queryItems as! [String: String], ["title": "hello", "message": "world"])
             
             let scheme = matcher.matchURL("/alert?title=hello&message=world", scheme: "myapp", from: from)!
             XCTAssertEqual(urlMatchComponents.pattern, scheme.pattern)
             XCTAssertEqual(urlMatchComponents.values as! [String: String], scheme.values as! [String: String])
-            XCTAssertEqual(urlMatchComponents.queryItems as! [String: String], ["title": "hello", "message": "world"])
         }();
         {
             let from = ["http://<path:url>"]
@@ -140,25 +138,21 @@ class URLMatcherPublicTests: XCTestCase {
             let urlMatchComponents = matcher.matchURL("http://google.com/search?q=URLNavigator", from: from)!
             XCTAssertEqual(urlMatchComponents.pattern, "http://<path:url>")
             XCTAssertEqual(urlMatchComponents.values as! [String: String], ["url": "google.com/search"])
-            XCTAssertEqual(urlMatchComponents.queryItems as! [String: String], ["q": "URLNavigator"])
             
             let scheme = matcher.matchURL("http://google.com/search?q=URLNavigator", scheme: "myapp", from: from)!
             XCTAssertEqual(urlMatchComponents.pattern, scheme.pattern)
             XCTAssertEqual(urlMatchComponents.values as! [String: String], scheme.values as! [String: String])
-            XCTAssertEqual(urlMatchComponents.queryItems as! [String: String], scheme.queryItems as! [String: String])
         }();
         {
             let from = ["http://<path:url>"]
             let urlMatchComponents = matcher.matchURL("http://google.com/search/?q=URLNavigator", from: from)!
             XCTAssertEqual(urlMatchComponents.pattern, "http://<path:url>")
             XCTAssertEqual(urlMatchComponents.values as! [String: String], ["url": "google.com/search"])
-            XCTAssertEqual(urlMatchComponents.queryItems as! [String: String], ["q": "URLNavigator"])
             
             let scheme = matcher.matchURL("http://google.com/search/?q=URLNavigator",
                                           scheme: "myapp", from: from)!
             XCTAssertEqual(urlMatchComponents.pattern, scheme.pattern)
             XCTAssertEqual(urlMatchComponents.values as! [String: String], scheme.values as! [String: String])
-            XCTAssertEqual(urlMatchComponents.queryItems as! [String: String], scheme.queryItems as! [String: String])
         }();
     }
 }


### PR DESCRIPTION
Reasons:
* We already have `queryParameters` and `queryItems` in `URLConvertible` (#13).
* [NSURLQueryItem](https://developer.apple.com/library/ios/documentation/Foundation/Reference/NSURLQueryItem_Class/) is only available in iOS 8.0 and later.

Related issues:
* `URLMatchComponents` is added in #20.
