### PR TITLE
Use correct local constant name

### DIFF
--- a/Sources/URLMatcher.swift
+++ b/Sources/URLMatcher.swift
@@ -141,7 +141,7 @@ public class URLMatcher {
         let URLString = URL.URLStringValue
         if let scheme = scheme where !URLString.containsString("://") {
             #if DEBUG
-                if !URLPatternString.hasPrefix("/") {
+                if !URLString.hasPrefix("/") {
                     NSLog("[Warning] URL pattern doesn't have leading slash(/): '\(URL)'")
                 }
             #endif


### PR DESCRIPTION
It looks like an older name (`URLPatternString`) was being used here instead of `URLString`. 