### PR TITLE
Make URLMatchComponents pattern and values public

### DIFF
--- a/Sources/URLMatcher.swift
+++ b/Sources/URLMatcher.swift
@@ -31,8 +31,8 @@ import Foundation
 ///     - pattern: The URL pattern that was matched.
 ///     - values: The values extracted from the URL.
 public struct URLMatchComponents {
-    let pattern: String
-    let values: [String : AnyObject]
+    public let pattern: String
+    public let values: [String : AnyObject]
 }
 
 /// URLMatcher provides a way to match URLs against a list of specified patterns.


### PR DESCRIPTION
This PR makes the `pattern` and `values` properties of `URLMatchComponents` public. This allows for callers of `URLMatcher.matchURL(_:scheme:from:)` to inspect the pattern and values in the return value of the call.