### PR TITLE
Allow for matching against root path

### DIFF
--- a/Sources/URLMatcher.swift
+++ b/Sources/URLMatcher.swift
@@ -154,7 +154,7 @@ open class URLMatcher {
   ///
   /// - Removing redundant trailing slash(/) on scheme
   /// - Removing redundant double-slashes(//)
-  /// - Removing trailing slash(/)
+  /// - Removing trailing slash(/) aside from slashes directly following the scheme
   ///
   /// - parameter dirtyURL: The dirty URL to be normalized.
   ///
@@ -167,7 +167,7 @@ open class URLMatcher {
     urlString = urlString.components(separatedBy: "?")[0].components(separatedBy: "#")[0]
     urlString = self.replaceRegex(":/{3,}", "://", urlString)
     urlString = self.replaceRegex("(?<!:)/{2,}", "/", urlString)
-    urlString = self.replaceRegex("/+$", "", urlString)
+    urlString = self.replaceRegex("(?<!:|:/)/+$", "", urlString)
     return urlString
   }
 

--- a/Tests/URLMatcherInternalTests.swift
+++ b/Tests/URLMatcherInternalTests.swift
@@ -54,6 +54,7 @@ class URLMatcherInternalTests: XCTestCase {
     XCTAssertEqual(matcher.normalized("myapp:///////user///<id>//hello/??/#abc=/def").urlStringValue,
                    "myapp://user/<id>/hello")
     XCTAssertEqual(matcher.normalized("https://<path:_>").urlStringValue, "https://<path:_>")
+    XCTAssertEqual(matcher.normalized("https://").urlStringValue, "https://")
   }
 
   func testPlaceholderValueFromURLPathComponents() {

--- a/Tests/URLNavigatorPublicTests.swift
+++ b/Tests/URLNavigatorPublicTests.swift
@@ -60,8 +60,8 @@ class URLNavigatorPublicTests: XCTestCase {
       "Hello"
     )
 
-    XCTAssertNil(self.navigator.viewController(for: "http://"))
-    XCTAssertNil(self.navigator.viewController(for: "https://"))
+    XCTAssert(self.navigator.viewController(for: "http://") is WebViewController)
+    XCTAssert(self.navigator.viewController(for: "https://") is WebViewController)
     XCTAssert(self.navigator.viewController(for: "http://xoul.kr") is WebViewController)
     XCTAssert(self.navigator.viewController(for: "http://xoul.kr/resume") is WebViewController)
     XCTAssert(self.navigator.viewController(for: "http://google.com/search?q=URLNavigator") is WebViewController)
@@ -155,8 +155,8 @@ class URLNavigatorPublicTests: XCTestCase {
     XCTAssert(self.navigator.viewController(for: "/post/123") is PostViewController)
     XCTAssert(self.navigator.viewController(for: "/post/hello-world") is PostViewController)
 
-    XCTAssertNil(self.navigator.viewController(for: "http://"))
-    XCTAssertNil(self.navigator.viewController(for: "https://"))
+    XCTAssert(self.navigator.viewController(for: "http://") is WebViewController)
+    XCTAssert(self.navigator.viewController(for: "https://") is WebViewController)
     XCTAssert(self.navigator.viewController(for: "http://xoul.kr") is WebViewController)
     XCTAssert(self.navigator.viewController(for: "http://xoul.kr/resume") is WebViewController)
     XCTAssert(self.navigator.viewController(for: "http://google.com/search?q=URLNavigator") is WebViewController)


### PR DESCRIPTION
Previously matching the root path (`/`) against the root URL (`scheme://`) would not work.

This was because `URLMatcher.normalized(_:scheme:)` would strip off any trailing slashes when normalizing a URL, this returning "scheme:", and not "scheme://" for the following method parameters:

```
path: "/"
scheme: "scheme"
```

This pull request adjusts `URLMatcher.normalized(_:scheme:)` to not strip away trailing slashes that directly follow the scheme. It also updates tests to match `http(s)://` to `http(s)://<path:_>`, since the root path is a valid path.