### PR TITLE
Prevent push/present same URL

### DIFF
--- a/Example/Sources/ViewControllers/UserViewController.swift
+++ b/Example/Sources/ViewControllers/UserViewController.swift
@@ -16,6 +16,7 @@ final class UserViewController: UIViewController {
 
   let username: String
   var repos = [Repo]()
+  var URL: URLConvertible?
 
 
   // MARK: UI Properties

--- a/Example/Sources/ViewControllers/WebViewController.swift
+++ b/Example/Sources/ViewControllers/WebViewController.swift
@@ -13,6 +13,10 @@ import URLNavigator
 
 final class WebViewController: UIViewController {
 
+  // MARK: Navigable
+  
+  var URL: URLConvertible?
+
   // MARK: UI Properties
 
   let webView = WKWebView()
@@ -64,7 +68,7 @@ final class WebViewController: UIViewController {
 // MARK: - URLNavigable
 
 extension WebViewController: URLNavigable {
-
+  
   convenience init?(url: URLConvertible, values: [String: Any]) {
     guard let URLVaue = url.urlValue else { return nil }
     self.init()

--- a/Sources/URLConvertible.swift
+++ b/Sources/URLConvertible.swift
@@ -61,6 +61,16 @@ extension URLConvertible {
   }
 }
 
+extension URLConvertible {
+  /// Compare URLConvertible with `self` by urlStringValue
+  ///
+  /// - Parameter url: given URLConvertible for comparing
+  /// - Returns: true if both `urlStringValue`'s are equal
+  public func compare(with url: URLConvertible?) -> Bool {
+    return url?.urlStringValue == self.urlStringValue
+  }
+}
+
 extension String: URLConvertible {
   public var urlValue: URL? {
     if let url = URL(string: self) {

--- a/Sources/URLNavigable.swift
+++ b/Sources/URLNavigable.swift
@@ -58,10 +58,7 @@ public protocol URLNavigable: class {
 /// Extension for allowing URL to be nil and optionally implemented
 public extension URLNavigable {
   
-  var URL: URLConvertible? { get { return nil } set (new) { URL = new } }
-  
   func set(url: URLConvertible?) {
     URL = url
   }
-  
 }

--- a/Sources/URLNavigable.swift
+++ b/Sources/URLNavigable.swift
@@ -25,7 +25,7 @@ import Foundation
 /// A type that can be initialized with URLs and values.
 ///
 /// - seealso: `URLNavigator`
-public protocol URLNavigable {
+public protocol URLNavigable: class {
 
   /// Creates an instance with specified URL and returns it. Returns `nil` if the URL and the values are not met the
   /// condition to create an instance.
@@ -51,11 +51,17 @@ public protocol URLNavigable {
   /// May be used for validating the sender and preventing creating a routing cycle
   var URL: URLConvertible? { get set }
   
+  func set(url: URLConvertible?)
+  
 }
 
 /// Extension for allowing URL to be nil and optionally implemented
 public extension URLNavigable {
   
   var URL: URLConvertible? { get { return nil } set (new) { URL = new } }
+  
+  func set(url: URLConvertible?) {
+    URL = url
+  }
   
 }

--- a/Sources/URLNavigable.swift
+++ b/Sources/URLNavigable.swift
@@ -45,5 +45,17 @@ public protocol URLNavigable {
   /// - parameter values: The URL pattern placeholder values by placeholder names. For example, if the URL pattern is
   ///     `myapp://user/<int:id>` and the given URL is `myapp://user/123`, values will be `["id": 123]`.
   init?(url: URLConvertible, values: [String: Any])
+    
+  /// Holds the URL of the conforming class.
+  ///
+  /// May be used for validating the sender and preventing creating a routing cycle
+  var URL: URLConvertible? { get set }
+  
+}
 
+/// Extension for allowing URL to be nil and optionally implemented
+public extension URLNavigable {
+  
+  var URL: URLConvertible? { get { return nil } set (new) { URL = new } }
+  
 }

--- a/Sources/URLNavigator.swift
+++ b/Sources/URLNavigator.swift
@@ -121,7 +121,9 @@ open class URLNavigator {
   open func viewController(for url: URLConvertible) -> UIViewController? {
     if let urlMatchComponents = URLMatcher.default.match(url, scheme: self.scheme, from: Array(self.urlMap.keys)) {
       let navigable = self.urlMap[urlMatchComponents.pattern]
-      return navigable?.init(url: url, values: urlMatchComponents.values) as? UIViewController
+      let viewController = navigable?.init(url: url, values: urlMatchComponents.values) as? UIViewController
+      (viewController as? URLNavigable)?.set(url: url)
+      return viewController
     }
     return nil
   }

--- a/Sources/URLNavigator.swift
+++ b/Sources/URLNavigator.swift
@@ -174,7 +174,8 @@ open class URLNavigator {
     from: UINavigationController? = nil,
     animated: Bool = true
   ) -> UIViewController? {
-    guard let navigationController = from ?? UIViewController.topMost?.navigationController else {
+    guard let navigationController = from ?? UIViewController.topMost?.navigationController,
+      shouldOpen(viewController: viewController, from: navigationController) else {
       return nil
     }
     navigationController.pushViewController(viewController, animated: animated)
@@ -236,7 +237,8 @@ open class URLNavigator {
     animated: Bool = true,
     completion: (() -> Void)? = nil
   ) -> UIViewController? {
-    guard let fromViewController = from ?? UIViewController.topMost else { return nil }
+    guard let fromViewController = from ?? UIViewController.topMost,
+      shouldOpen(viewController: viewController, from: fromViewController) else { return nil }
     if wrap {
       let navigationController = UINavigationController(rootViewController: viewController)
       fromViewController.present(navigationController, animated: animated, completion: nil)
@@ -267,6 +269,35 @@ open class URLNavigator {
   }
 }
 
+// MARK: - Opening controller helpers
+private extension URLNavigator {
+  
+  
+  /// Validates if a UIViewController shouldOpen from a given URLConvertible; `viewController` needs to conform to *URLNavigable* protocol. This prevents opening/pushing/presenting the same URLNavigable.
+  ///
+  /// - parameter viewController: The opening UIViewController
+  /// - parameter url: The URLConvertible to compare with
+  ///
+  /// - returns: true if url isn't equal to `viewController`'s URLConvertible
+  func shouldOpen(viewController: UIViewController, from url: URLConvertible) -> Bool {
+    guard let navigable = viewController as? URLNavigable else { return false }
+    guard let result = navigable.URL?.compare(with: url), result == false
+      else { return false }
+    return !result
+  }
+  
+  
+  /// Validates if a UIViewController shouldOpen comming from a given UIViewController; Both UIViewController's need to conform to *URLNavigable* protocol. This prevents opening/pushing/presenting the same URLNavigable
+  ///
+  /// - parameter viewController: The opening UIViewController
+  /// - parameter from: The UIViewController it is trying to open from
+  ///
+  /// - returns: true if both UIViewController's URLConvertible don't match
+  func shouldOpen(viewController: UIViewController, from: UIViewController) -> Bool {
+    guard let from = from as? URLNavigable, let url = from.URL else { return true }
+    return shouldOpen(viewController: viewController, from: url)
+  }
+}
 
 // MARK: - Default Navigator
 

--- a/Tests/URLNavigatorPublicTests.swift
+++ b/Tests/URLNavigatorPublicTests.swift
@@ -74,6 +74,7 @@ class URLNavigatorPublicTests: XCTestCase {
     let navigationController = UINavigationController(rootViewController: UIViewController())
     let viewController = self.navigator.push("myapp://user/1", from: navigationController, animated: false)
     XCTAssertNotNil(viewController)
+    XCTAssertNotNil((viewController as? URLNavigable)?.URL)
     XCTAssertEqual(navigationController.viewControllers.count, 2)
   }
 
@@ -84,6 +85,16 @@ class URLNavigatorPublicTests: XCTestCase {
     XCTAssertNil(viewController)
     XCTAssertEqual(navigationController.viewControllers.count, 1)
   }
+  
+  func testPushSameURL_URLNavigable() {
+    self.navigator.map("myapp://user/<int:id>", UserViewController.self)
+    let navigationController = UINavigationController(rootViewController: UIViewController())
+    let viewController = self.navigator.push("myapp://user/1", from: navigationController, animated: false)
+    let sameViewController = self.navigator.push("myapp://user/1", animated: false)
+    XCTAssertNotNil(viewController)
+    XCTAssertNil(sameViewController)
+    XCTAssertEqual(navigationController.viewControllers.count, 2)
+  }
 
   func testPresentURL_URLNavigable() {
     self.navigator.map("myapp://user/<int:id>", UserViewController.self)
@@ -91,12 +102,14 @@ class URLNavigatorPublicTests: XCTestCase {
       let fromViewController = UIViewController()
       let viewController = self.navigator.present("myapp://user/1", from: fromViewController)
       XCTAssertNotNil(viewController)
+      XCTAssertNotNil((viewController as? URLNavigable)?.URL)
       XCTAssertNil(viewController?.navigationController)
     }();
     {
       let fromViewController = UIViewController()
       let viewController = self.navigator.present("myapp://user/1", wrap: true, from: fromViewController)
       XCTAssertNotNil(viewController)
+      XCTAssertNotNil((viewController as? URLNavigable)?.URL)
       XCTAssertNotNil(viewController?.navigationController)
     }();
   }
@@ -105,6 +118,16 @@ class URLNavigatorPublicTests: XCTestCase {
     self.navigator.map("myapp://ping") { _ in return true }
     let fromViewController = UIViewController()
     let viewController = self.navigator.present("myapp://ping", from: fromViewController)
+    XCTAssertNil(viewController)
+  }
+  
+  func testPresentSameURL_URLNavigable() {
+    self.navigator.map("myapp://user/<int:id>", UserViewController.self)
+    let navigationController = UINavigationController(rootViewController: UIViewController())
+    let fromViewController = self.navigator.push("myapp://user/1", from: navigationController, animated: false)
+    
+    let viewController = self.navigator.present("myapp://user/1", from: fromViewController)
+    
     XCTAssertNil(viewController)
   }
 
@@ -229,6 +252,7 @@ class URLNavigatorPublicTests: XCTestCase {
 private class UserViewController: UIViewController, URLNavigable {
 
   var userID: Int?
+  var URL: URLConvertible?
 
   convenience required init?(url: URLConvertible, values: [String: Any]) {
     guard let id = values["id"] as? Int else {
@@ -243,6 +267,7 @@ private class UserViewController: UIViewController, URLNavigable {
 private class PostViewController: UIViewController, URLNavigable {
 
   var postTitle: String?
+  var URL: URLConvertible?
 
   convenience required init?(url: URLConvertible, values: [String: Any]) {
     guard let title = values["title"] as? String else {
@@ -257,6 +282,7 @@ private class PostViewController: UIViewController, URLNavigable {
 private class WebViewController: UIViewController, URLNavigable {
 
   var url: URLConvertible?
+  var URL: URLConvertible?
 
   convenience required init?(url: URLConvertible, values: [String: Any]) {
     self.init()
@@ -268,6 +294,7 @@ private class WebViewController: UIViewController, URLNavigable {
 private class SearchViewController: UIViewController, URLNavigable {
 
   let query: String
+  var URL: URLConvertible?
 
   init(query: String) {
     self.query = query


### PR DESCRIPTION
Hey!
## Problem
This PR tries to solve the problem related to issue #30.
Routing to a same ViewController is allowed and control must be made on the app side. Preventing this logic should be on the URLNavigator side, providing a more safe and controlled routing framework.

## Solution
The encountered solution was to give the URLNavigable conforming classes some way to keep it's URL without the effort of those classes having to store it themselves.
The URLNavigator class gets the responsibility to set this url when initialising each object.
Then, upon pushing or presenting an UIViewController, the URLNavigator is responsible for comparing the URL's of the sender and target.

## Test and reproduce
I've added some tests `testPushSameURL_URLNavigable()` and `testPresentSameURL_URLNavigable()` for testing this behaviour, as well as validations for the URL to the other tests

## Caveat
If you haven't noticed yet, this approach doesn't prevent the target UIViewController from being initialised as the validation is only made right before pushing/presenting the target. I'm not still able to see some solution to work around this.

I would thanks for some feedback on this. If you think this may be the best solution for now or some other that you now see may be possible.

Thanks for building URLNavigator,
Francisco