### PR TITLE
Add URLConvertible type alias to URLNavigator class

### DIFF
--- a/Sources/URLNavigator.swift
+++ b/Sources/URLNavigator.swift
@@ -22,6 +22,9 @@
 
 import UIKit
 
+/// A typealias for avoiding namespace conflict.
+public typealias _URLConvertible = URLConvertible
+
 /// URLNavigator provides an elegant way to navigate through view controllers by URLs. URLs should be mapped by using
 /// `URLNavigator.map(_:_:)` function.
 ///
@@ -56,6 +59,9 @@ import UIKit
 ///
 /// - seealso: `URLNavigable`
 open class URLNavigator {
+
+  /// A typealias for avoiding namespace conflict.
+  public typealias URLConvertible = _URLConvertible
 
   /// A closure type which has URL and values for parameters.
   public typealias URLOpenHandler = (_ url: URLConvertible, _ values: [String: Any]) -> Bool


### PR DESCRIPTION
### Background

```swift
import Alamofire
import URLNavigator

// 🚫 'URLConvertible' is ambiguous for type lookup in this context
// ❓ There are two candidates: `Alamofire. URLConvertible` and `URLNavigator.URLConvertible`.
func foo(url: URLConvertible) {
}

// 🚫 'URLConvertible' is not a member type of 'URLNavigator'
// ❓ Compiler uses `URLNavigator` class rather than the module.
func bar(url: URLNavigator.URLConvertible!) {
}
```

### Solution

Add `URLConvertible` alias to `URLNavigator` class to let compiler find the reference correctly.

### Related issues

- Fixes #39
