### PR TITLE
Add URLNavigatorDelegate to pre handle URL and view controller presentation

### DIFF
--- a/Sources/URLNavigator.swift
+++ b/Sources/URLNavigator.swift
@@ -163,9 +163,10 @@ open class URLNavigator {
     from: UINavigationController? = nil,
     animated: Bool = true
   ) -> UIViewController? {
-    guard let viewController = self.viewController(for: url, userInfo: userInfo) else {
-      return nil
+    if let delegate = delegate {
+        guard delegate.shouldPush(url: url, userInfo: userInfo, from: from, animated: animated) else { return nil }
     }
+    guard let viewController = self.viewController(for: url, userInfo: userInfo) else { return nil }
     delegate?.willPush(url: url, userInfo: userInfo, from: from, animated: animated)
     return self.push(viewController, from: from, animated: animated)
   }
@@ -184,9 +185,10 @@ open class URLNavigator {
     from: UINavigationController? = nil,
     animated: Bool = true
   ) -> UIViewController? {
-    guard let navigationController = from ?? UIViewController.topMost?.navigationController else {
-      return nil
+    if let delegate = delegate {
+      guard delegate.shouldPush(viewController: viewController, from: from, animated: animated) else { return nil }
     }
+    guard let navigationController = from ?? UIViewController.topMost?.navigationController else { return nil }
     delegate?.willPush(viewController: viewController, from: from, animated: animated)
     navigationController.pushViewController(viewController, animated: animated)
     return viewController
@@ -225,6 +227,9 @@ open class URLNavigator {
     animated: Bool = true,
     completion: (() -> Void)? = nil
   ) -> UIViewController? {
+    if let delegate = delegate {
+      guard delegate.shouldPresent(url: url, userInfo: userInfo, wrap: wrap, from: from, animated: animated) else { return nil }
+    }
     guard let viewController = self.viewController(for: url, userInfo: userInfo) else { return nil }
     delegate?.willPresent(url: url, userInfo: userInfo, wrap: wrap, from: from, animated: animated)
     return self.present(viewController, wrap: wrap, from: from, animated: animated, completion: completion)
@@ -249,6 +254,9 @@ open class URLNavigator {
     animated: Bool = true,
     completion: (() -> Void)? = nil
   ) -> UIViewController? {
+    if let delegate = delegate {
+      guard delegate.shouldPresent(viewController: viewController, wrap: wrap, from: from, animated: animated) else { return nil }
+    }
     guard let fromViewController = from ?? UIViewController.topMost else { return nil }
     delegate?.willPresent(viewController: viewController, wrap: wrap, from: from, animated: animated)
     if wrap {
@@ -270,7 +278,12 @@ open class URLNavigator {
   /// - returns: The return value of the matching `URLOpenHandler`. Returns `false` if there's no match.
   @discardableResult
   open func open(_ url: URLConvertible) -> Bool {
+    if let delegate = delegate {
+      guard delegate.shouldOpen(url: url) else { return false }
+    }
+    
     delegate?.willOpen(url: url)
+    
     let urlOpenHandlersKeys = Array(self.urlOpenHandlers.keys)
     if let urlMatchComponents = URLMatcher.default.match(url, scheme: self.scheme, from: urlOpenHandlersKeys) {
       let handler = self.urlOpenHandlers[urlMatchComponents.pattern]

--- a/Sources/URLNavigator.swift
+++ b/Sources/URLNavigator.swift
@@ -60,6 +60,9 @@ public typealias _URLConvertible = URLConvertible
 /// - seealso: `URLNavigable`
 open class URLNavigator {
 
+  /// The delegate
+  public weak var delegate: URLNavigatorDelegate?
+    
   /// A typealias for avoiding namespace conflict.
   public typealias URLConvertible = _URLConvertible
 
@@ -163,6 +166,7 @@ open class URLNavigator {
     guard let viewController = self.viewController(for: url, userInfo: userInfo) else {
       return nil
     }
+    delegate?.willPush(url: url, userInfo: userInfo, from: from, animated: animated)
     return self.push(viewController, from: from, animated: animated)
   }
 
@@ -183,6 +187,7 @@ open class URLNavigator {
     guard let navigationController = from ?? UIViewController.topMost?.navigationController else {
       return nil
     }
+    delegate?.willPush(viewController: viewController, from: from, animated: animated)
     navigationController.pushViewController(viewController, animated: animated)
     return viewController
   }
@@ -221,6 +226,7 @@ open class URLNavigator {
     completion: (() -> Void)? = nil
   ) -> UIViewController? {
     guard let viewController = self.viewController(for: url, userInfo: userInfo) else { return nil }
+    delegate?.willPresent(url: url, userInfo: userInfo, wrap: wrap, from: from, animated: animated)
     return self.present(viewController, wrap: wrap, from: from, animated: animated, completion: completion)
   }
 
@@ -244,6 +250,7 @@ open class URLNavigator {
     completion: (() -> Void)? = nil
   ) -> UIViewController? {
     guard let fromViewController = from ?? UIViewController.topMost else { return nil }
+    delegate?.willPresent(viewController: viewController, wrap: wrap, from: from, animated: animated)
     if wrap {
       let navigationController = UINavigationController(rootViewController: viewController)
       fromViewController.present(navigationController, animated: animated, completion: nil)
@@ -263,6 +270,7 @@ open class URLNavigator {
   /// - returns: The return value of the matching `URLOpenHandler`. Returns `false` if there's no match.
   @discardableResult
   open func open(_ url: URLConvertible) -> Bool {
+    delegate?.willOpen(url: url)
     let urlOpenHandlersKeys = Array(self.urlOpenHandlers.keys)
     if let urlMatchComponents = URLMatcher.default.match(url, scheme: self.scheme, from: urlOpenHandlersKeys) {
       let handler = self.urlOpenHandlers[urlMatchComponents.pattern]

--- a/Sources/URLNavigatorDelegate.swift
+++ b/Sources/URLNavigatorDelegate.swift
@@ -78,7 +78,7 @@ public protocol URLNavigatorDelegate: class {
     
   // MARK: Pushing View Controllers with URL
 
-  /// Called before opening the URL. Default does nothing.
+  /// Called before opening the URL.
   /// This is called regardless if the presentation was successful.
   ///
   /// - parameter url: The URL to find view controllers.
@@ -89,7 +89,7 @@ public protocol URLNavigatorDelegate: class {
   /// - returns: True if the view should be pushed. The default is true.
   func shouldPush(url: URLConvertible, userInfo: [AnyHashable: Any]?, from: UINavigationController?, animated: Bool) -> Bool
 
-  /// Called before view controller is pushed. Default does nothing.
+  /// Called before view controller is pushed.
   ///
   /// - parameter viewController: The `UIViewController` instance to be pushed.
   /// - parameter from: The navigation controller which is used to push a view controller. Use application's top-most
@@ -101,7 +101,7 @@ public protocol URLNavigatorDelegate: class {
 
   // MARK: Presenting View Controllers with URL
 
-  /// Called before opening the URL. Default does nothing.
+  /// Called before opening the URL.
   /// This is called regardless if the presentation was successful.
   ///
   /// - parameter url: The URL to find view controllers.
@@ -114,7 +114,7 @@ public protocol URLNavigatorDelegate: class {
   /// - returns: True if the view should be pushed. The default is true.
   func shouldPresent(url: URLConvertible, userInfo: [AnyHashable: Any]?, wrap: Bool, from: UIViewController?, animated: Bool) -> Bool
     
-  /// Called before the view controller is presented. Default does nothing.
+  /// Called before the view controller is presented.
   /// This is called regardless if the presentation was successful.
   ///
   /// - parameter viewController: The `UIViewController` instance to be presented.
@@ -129,7 +129,7 @@ public protocol URLNavigatorDelegate: class {
 
   // MARK: Opening URL.
 
-  /// Called when before opening the url. Default does nothing.
+  /// Called when before opening the url.
   /// This is called regardless if the presentation was successful.
   ///
   /// - parameter url: The URL to find `URLOpenHandler`s.

--- a/Sources/URLNavigatorDelegate.swift
+++ b/Sources/URLNavigatorDelegate.swift
@@ -15,83 +15,168 @@ import UIKit
 ///
 public protocol URLNavigatorDelegate: class {
 
-    // MARK: Pushing View Controllers with URL
+  // MARK: Pushing View Controllers with URL
     
-    /// Called before opening the URL. Default does nothing.
-    /// This is called regardless if the presentation was successful.    
-    ///
-    /// - parameter url: The URL to find view controllers.
-    /// - parameter from: The navigation controller which is used to push a view controller. Use application's top-most
-    ///     view controller if `nil` is specified. `nil` by default.
-    /// - parameter animated: Whether animates view controller transition or not. `true` by default.
-    ///
-    func willPush(url: URLConvertible, userInfo: [AnyHashable: Any]?, from: UINavigationController?, animated: Bool)
+  /// Called before opening the URL. Default does nothing.
+  /// This is called regardless if the presentation was successful.
+  ///
+  /// - parameter url: The URL to find view controllers.
+  /// - parameter from: The navigation controller which is used to push a view controller. Use application's top-most
+  ///     view controller if `nil` is specified. `nil` by default.
+  /// - parameter animated: Whether animates view controller transition or not. `true` by default.
+  ///
+  func willPush(url: URLConvertible, userInfo: [AnyHashable: Any]?, from: UINavigationController?, animated: Bool)
+
+
+  /// Called before view controller is pushed. Default does nothing.
+  ///
+  /// - parameter viewController: The `UIViewController` instance to be pushed.
+  /// - parameter from: The navigation controller which is used to push a view controller. Use application's top-most
+  ///     view controller if `nil` is specified. `nil` by default.
+  /// - parameter animated: Whether animates view controller transition or not. `true` by default.
+  ///
+  func willPush(viewController: UIViewController, from: UINavigationController?, animated: Bool)
+
+
+  // MARK: Presenting View Controllers with URL
+
+  /// Called before opening the URL. Default does nothing.
+  /// This is called regardless if the presentation was successful.
+  ///
+  /// - parameter url: The URL to find view controllers.
+  /// - parameter wrap: Wraps the view controller with a `UINavigationController` if `true` is specified. `false` by
+  ///     default.
+  /// - parameter from: The view controller which is used to present a view controller. Use application's top-most
+  ///     view controller if `nil` is specified. `nil` by default.
+  /// - parameter animated: Whether animates view controller transition or not. `true` by default.
+  func willPresent(url: URLConvertible, userInfo: [AnyHashable: Any]?, wrap: Bool, from: UIViewController?, animated: Bool)
+
+
+  /// Called before the view controller is presented. Default does nothing.
+  /// This is called regardless if the presentation was successful.
+  ///
+  /// - parameter viewController: The `UIViewController` instance to be presented.
+  /// - parameter wrap: Wraps the view controller with a `UINavigationController` if `true` is specified. `false` by
+  ///     default.
+  /// - parameter from: The view controller which is used to present a view controller. Use application's top-most
+  ///     view controller if `nil` is specified. `nil` by default.
+  /// - parameter animated: Whether animates view controller transition or not. `true` by default.
+  func willPresent(viewController: UIViewController, wrap: Bool, from: UIViewController?, animated: Bool)
+
+
+  // MARK: Opening URL
+
+  /// Called when before opening the url. Default does nothing.
+  /// This is called regardless if the presentation was successful.
+  ///
+  /// - parameter url: The URL to find `URLOpenHandler`s.
+  func willOpen(url: URLConvertible)
     
     
-    /// Called before view controller is pushed. Default does nothing.
-    ///
-    /// - parameter viewController: The `UIViewController` instance to be pushed.
-    /// - parameter from: The navigation controller which is used to push a view controller. Use application's top-most
-    ///     view controller if `nil` is specified. `nil` by default.
-    /// - parameter animated: Whether animates view controller transition or not. `true` by default.
-    ///
-    func willPush(viewController: UIViewController, from: UINavigationController?, animated: Bool)
+  // MARK: Should perform an action.
     
     
-    // MARK: Presenting View Controllers with URL
+  // MARK: Pushing View Controllers with URL
+
+  /// Called before opening the URL. Default does nothing.
+  /// This is called regardless if the presentation was successful.
+  ///
+  /// - parameter url: The URL to find view controllers.
+  /// - parameter from: The navigation controller which is used to push a view controller. Use application's top-most
+  ///     view controller if `nil` is specified. `nil` by default.
+  /// - parameter animated: Whether animates view controller transition or not. `true` by default.
+  ///
+  /// - returns: True if the view should be pushed. The default is true.
+  func shouldPush(url: URLConvertible, userInfo: [AnyHashable: Any]?, from: UINavigationController?, animated: Bool) -> Bool
+
+  /// Called before view controller is pushed. Default does nothing.
+  ///
+  /// - parameter viewController: The `UIViewController` instance to be pushed.
+  /// - parameter from: The navigation controller which is used to push a view controller. Use application's top-most
+  ///     view controller if `nil` is specified. `nil` by default.
+  /// - parameter animated: Whether animates view controller transition or not. `true` by default.
+  ///
+  /// - returns: True if the view should be pushed. The default is true.
+  func shouldPush(viewController: UIViewController, from: UINavigationController?, animated: Bool) -> Bool
+
+  // MARK: Presenting View Controllers with URL
+
+  /// Called before opening the URL. Default does nothing.
+  /// This is called regardless if the presentation was successful.
+  ///
+  /// - parameter url: The URL to find view controllers.
+  /// - parameter wrap: Wraps the view controller with a `UINavigationController` if `true` is specified. `false` by
+  ///     default.
+  /// - parameter from: The view controller which is used to present a view controller. Use application's top-most
+  ///     view controller if `nil` is specified. `nil` by default.
+  /// - parameter animated: Whether animates view controller transition or not. `true` by default.
+  ///
+  /// - returns: True if the view should be pushed. The default is true.
+  func shouldPresent(url: URLConvertible, userInfo: [AnyHashable: Any]?, wrap: Bool, from: UIViewController?, animated: Bool) -> Bool
     
-    /// Called before opening the URL. Default does nothing.
-    /// This is called regardless if the presentation was successful.
-    ///
-    /// - parameter url: The URL to find view controllers.
-    /// - parameter wrap: Wraps the view controller with a `UINavigationController` if `true` is specified. `false` by
-    ///     default.
-    /// - parameter from: The view controller which is used to present a view controller. Use application's top-most
-    ///     view controller if `nil` is specified. `nil` by default.
-    /// - parameter animated: Whether animates view controller transition or not. `true` by default.
-    func willPresent(url: URLConvertible, userInfo: [AnyHashable: Any]?, wrap: Bool, from: UIViewController?, animated: Bool)
-    
-    
-    /// Called before the view controller is presented. Default does nothing.
-    /// This is called regardless if the presentation was successful.
-    ///
-    /// - parameter viewController: The `UIViewController` instance to be presented.
-    /// - parameter wrap: Wraps the view controller with a `UINavigationController` if `true` is specified. `false` by
-    ///     default.
-    /// - parameter from: The view controller which is used to present a view controller. Use application's top-most
-    ///     view controller if `nil` is specified. `nil` by default.
-    /// - parameter animated: Whether animates view controller transition or not. `true` by default.
-    func willPresent(viewController: UIViewController, wrap: Bool, from: UIViewController?, animated: Bool)
-    
-    
-    // MARK: Opening URL
-    
-    /// Called when before opening the url. Default does nothing.
-    /// This is called regardless if the presentation was successful.
-    ///
-    /// - parameter url: The URL to find `URLOpenHandler`s.
-    func willOpen(url: URLConvertible)
+  /// Called before the view controller is presented. Default does nothing.
+  /// This is called regardless if the presentation was successful.
+  ///
+  /// - parameter viewController: The `UIViewController` instance to be presented.
+  /// - parameter wrap: Wraps the view controller with a `UINavigationController` if `true` is specified. `false` by
+  ///     default.
+  /// - parameter from: The view controller which is used to present a view controller. Use application's top-most
+  ///     view controller if `nil` is specified. `nil` by default.
+  /// - parameter animated: Whether animates view controller transition or not. `true` by default.
+  ///
+  /// - returns: True if the view should be pushed. The default is true.
+  func shouldPresent(viewController: UIViewController, wrap: Bool, from: UIViewController?, animated: Bool) -> Bool
+
+  // MARK: Opening URL.
+
+  /// Called when before opening the url. Default does nothing.
+  /// This is called regardless if the presentation was successful.
+  ///
+  /// - parameter url: The URL to find `URLOpenHandler`s.
+  ///
+  /// - returns: True if the view should be pushed. The default is true.
+  func shouldOpen(url: URLConvertible) -> Bool
 }
 
 public extension URLNavigatorDelegate {
     
-    func willPush(url: URLConvertible, userInfo: [AnyHashable: Any]?, from: UINavigationController?, animated: Bool) {
-        
-    }
+  func willPush(url: URLConvertible, userInfo: [AnyHashable: Any]?, from: UINavigationController?, animated: Bool) {
+    
+  }
 
-    func willPush(viewController: UIViewController, from: UINavigationController?, animated: Bool) {
-        
-    }
+  func willPush(viewController: UIViewController, from: UINavigationController?, animated: Bool) {
     
-    func willPresent(url: URLConvertible, userInfo: [AnyHashable: Any]?, wrap: Bool, from: UIViewController?, animated: Bool) {
-        
-    }
+  }
+
+  func willPresent(url: URLConvertible, userInfo: [AnyHashable: Any]?, wrap: Bool, from: UIViewController?, animated: Bool) {
     
-    func willPresent(viewController: UIViewController, wrap: Bool, from: UIViewController?, animated: Bool) {
-        
-    }
+  }
+
+  func willPresent(viewController: UIViewController, wrap: Bool, from: UIViewController?, animated: Bool) {
     
-    func willOpen(url: URLConvertible) {
-        
-    }
+  }
+
+  func willOpen(url: URLConvertible) {
+    
+  }
+    
+  func shouldPush(url: URLConvertible, userInfo: [AnyHashable: Any]?, from: UINavigationController?, animated: Bool) -> Bool {
+    return true
+  }
+    
+  func shouldPush(viewController: UIViewController, from: UINavigationController?, animated: Bool) -> Bool {
+    return true
+  }
+    
+  func shouldPresent(url: URLConvertible, userInfo: [AnyHashable: Any]?, wrap: Bool, from: UIViewController?, animated: Bool) -> Bool {
+    return true
+  }
+    
+  func shouldPresent(viewController: UIViewController, wrap: Bool, from: UIViewController?, animated: Bool) -> Bool {
+    return true
+  }
+    
+  func willOpen(url: URLConvertible) -> Bool {
+    return true
+  }
 }

--- a/Sources/URLNavigatorDelegate.swift
+++ b/Sources/URLNavigatorDelegate.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Suyeol Jeon. All rights reserved.
 //
 
-import Foundation
+import UIKit
 
 ///
 /// Delegate methods to be called prior to opening a URL or presenting a view controller.

--- a/Sources/URLNavigatorDelegate.swift
+++ b/Sources/URLNavigatorDelegate.swift
@@ -72,3 +72,26 @@ public protocol URLNavigatorDelegate: class {
     /// - parameter url: The URL to find `URLOpenHandler`s.
     func willOpen(url: URLConvertible)
 }
+
+extension URLNavigatorDelegate {
+    
+    func willPush(url: URLConvertible, userInfo: [AnyHashable: Any]?, from: UINavigationController?, animated: Bool) {
+        
+    }
+
+    func willPush(viewController: UIViewController, from: UINavigationController?, animated: Bool) {
+        
+    }
+    
+    func willPresent(url: URLConvertible, userInfo: [AnyHashable: Any]?, wrap: Bool, from: UIViewController?, animated: Bool) {
+        
+    }
+    
+    func willPresent(viewController: UIViewController, wrap: Bool, from: UIViewController?, animated: Bool) {
+        
+    }
+    
+    func willOpen(url: URLConvertible) {
+        
+    }
+}

--- a/Sources/URLNavigatorDelegate.swift
+++ b/Sources/URLNavigatorDelegate.swift
@@ -73,7 +73,7 @@ public protocol URLNavigatorDelegate: class {
     func willOpen(url: URLConvertible)
 }
 
-extension URLNavigatorDelegate {
+public extension URLNavigatorDelegate {
     
     func willPush(url: URLConvertible, userInfo: [AnyHashable: Any]?, from: UINavigationController?, animated: Bool) {
         

--- a/Sources/URLNavigatorDelegate.swift
+++ b/Sources/URLNavigatorDelegate.swift
@@ -176,7 +176,7 @@ public extension URLNavigatorDelegate {
     return true
   }
     
-  func willOpen(url: URLConvertible) -> Bool {
+  func shouldOpen(url: URLConvertible) -> Bool {
     return true
   }
 }

--- a/Sources/URLNavigatorDelegate.swift
+++ b/Sources/URLNavigatorDelegate.swift
@@ -1,0 +1,74 @@
+//
+//  URLNavigatorDelegate.swift
+//  URLNavigator
+//
+//  Created by David Le on 1/8/17.
+//  Copyright © 2017 Suyeol Jeon. All rights reserved.
+//
+
+import Foundation
+
+///
+/// Delegate methods to be called prior to opening a URL or presenting a view controller.
+///
+/// Each delegate method corresponds to a method of opening URLs or presenting view controllers in URLNavigator.
+///
+public protocol URLNavigatorDelegate: class {
+
+    // MARK: Pushing View Controllers with URL
+    
+    /// Called before opening the URL. Default does nothing.
+    /// This is called regardless if the presentation was successful.    
+    ///
+    /// - parameter url: The URL to find view controllers.
+    /// - parameter from: The navigation controller which is used to push a view controller. Use application's top-most
+    ///     view controller if `nil` is specified. `nil` by default.
+    /// - parameter animated: Whether animates view controller transition or not. `true` by default.
+    ///
+    func willPush(url: URLConvertible, userInfo: [AnyHashable: Any]?, from: UINavigationController?, animated: Bool)
+    
+    
+    /// Called before view controller is pushed. Default does nothing.
+    ///
+    /// - parameter viewController: The `UIViewController` instance to be pushed.
+    /// - parameter from: The navigation controller which is used to push a view controller. Use application's top-most
+    ///     view controller if `nil` is specified. `nil` by default.
+    /// - parameter animated: Whether animates view controller transition or not. `true` by default.
+    ///
+    func willPush(viewController: UIViewController, from: UINavigationController?, animated: Bool)
+    
+    
+    // MARK: Presenting View Controllers with URL
+    
+    /// Called before opening the URL. Default does nothing.
+    /// This is called regardless if the presentation was successful.
+    ///
+    /// - parameter url: The URL to find view controllers.
+    /// - parameter wrap: Wraps the view controller with a `UINavigationController` if `true` is specified. `false` by
+    ///     default.
+    /// - parameter from: The view controller which is used to present a view controller. Use application's top-most
+    ///     view controller if `nil` is specified. `nil` by default.
+    /// - parameter animated: Whether animates view controller transition or not. `true` by default.
+    func willPresent(url: URLConvertible, userInfo: [AnyHashable: Any]?, wrap: Bool, from: UIViewController?, animated: Bool)
+    
+    
+    /// Called before the view controller is presented. Default does nothing.
+    /// This is called regardless if the presentation was successful.
+    ///
+    /// - parameter viewController: The `UIViewController` instance to be presented.
+    /// - parameter wrap: Wraps the view controller with a `UINavigationController` if `true` is specified. `false` by
+    ///     default.
+    /// - parameter from: The view controller which is used to present a view controller. Use application's top-most
+    ///     view controller if `nil` is specified. `nil` by default.
+    /// - parameter animated: Whether animates view controller transition or not. `true` by default.
+    func willPresent(viewController: UIViewController, wrap: Bool, from: UIViewController?, animated: Bool)
+    
+    
+    // MARK: Opening URL
+    
+    /// Called when before opening the url. Default does nothing.
+    /// This is called regardless if the presentation was successful.
+    ///
+    /// - parameter url: The URL to find `URLOpenHandler`s.
+    func willOpen(url: URLConvertible)
+}

--- a/URLNavigator.xcodeproj/project.pbxproj
+++ b/URLNavigator.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		03D35EA31D35371A00452731 /* RepoCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D35EA21D35371A00452731 /* RepoCell.swift */; };
 		03D35EA51D3567AF00452731 /* UserCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D35EA41D3567AF00452731 /* UserCell.swift */; };
 		03D35EA71D3569ED00452731 /* WebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D35EA61D3569ED00452731 /* WebViewController.swift */; };
+		72FB898C1E234ACD000381BE /* URLNavigatorDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72FB898B1E234ACD000381BE /* URLNavigatorDelegate.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -94,6 +95,7 @@
 		03D35EA21D35371A00452731 /* RepoCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RepoCell.swift; sourceTree = "<group>"; };
 		03D35EA41D3567AF00452731 /* UserCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserCell.swift; sourceTree = "<group>"; };
 		03D35EA61D3569ED00452731 /* WebViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebViewController.swift; sourceTree = "<group>"; };
+		72FB898B1E234ACD000381BE /* URLNavigatorDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLNavigatorDelegate.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -153,6 +155,7 @@
 				03107EE11C6365BF00DF2F14 /* URLNavigable.swift */,
 				03107EE31C6365E500DF2F14 /* URLConvertible.swift */,
 				03107EE51C6366F500DF2F14 /* UIViewController+TopMostViewController.swift */,
+				72FB898B1E234ACD000381BE /* URLNavigatorDelegate.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -405,6 +408,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				72FB898C1E234ACD000381BE /* URLNavigatorDelegate.swift in Sources */,
 				03107EE61C6366F500DF2F14 /* UIViewController+TopMostViewController.swift in Sources */,
 				03107EE01C63653900DF2F14 /* URLNavigator.swift in Sources */,
 				02E016081D79E45E00BB7E25 /* URLMatcher.swift in Sources */,


### PR DESCRIPTION
Add URLNavigatorDelegate to pre handle URL and view controller presentation.

Example use case.
An app has 3 tabs and each tab can be opened with the following urls `/tab1`, `/tab2`, `/tab3`. 

If we have urls `/tab3` and `tab3/123` and we would like to select `tab3` first before continuing to open `tab3/123` then set a delegate to `Navigator` then implement `willOpen(url:)`. In the delegate method, select the desired tab.
