### PR TITLE
Improve topMost computed var with all windows checking

### DIFF
--- a/Sources/UIViewController+TopMostViewController.swift
+++ b/Sources/UIViewController+TopMostViewController.swift
@@ -26,7 +26,16 @@ extension UIViewController {
 
   /// Returns the current application's top most view controller.
   open class var topMost: UIViewController? {
-    let rootViewController = UIApplication.shared.windows.first?.rootViewController
+    var rootViewController: UIViewController?
+    let currentWindows = UIApplication.shared.windows
+    
+    for window in currentWindows {
+      if let windowRootViewController = window.rootViewController {
+        rootViewController = windowRootViewController
+        break
+      }
+    }
+    
     return self.topMost(of: rootViewController)
   }
 


### PR DESCRIPTION
Some applications have specific behavior with multiple windows. This is true specifically when you integrate some Ad SDK (like... Google Ads) or Passcode behavior. It consist of using an UIWindow with no specific rootViewController but just with a view inside.

Here an example with Google-Mobile-Ads-SDK :

The app start and Google show an interstitial, here the view hierarchy :
<img width="273" alt="start" src="https://cloud.githubusercontent.com/assets/2437702/23204219/fd31b428-f8e5-11e6-9cb9-50c8ff202264.png">

When the interstitial is hidden, the UIWindow go back to first position into the view hierarchy :
<img width="276" alt="afterinterstitialdismiss" src="https://cloud.githubusercontent.com/assets/2437702/23204253/1df75abe-f8e6-11e6-8b27-986ba93a01ae.png">

It is just an example and other Ad SDKs run like that. Some Passcode or login behavior run also like this.

So **because we want the topMost controller of the entire app**, I improve the `topMost` computed var to loop into all windows of the current app, and stop when a `rootViewController` is found into an UIWindow.

Another approach is to use the `keyWindow` property but I had some issue in the past because `makeKeyAndVisible` is not necessary called...

What do you think about it ?
