### PR TITLE
Add support mappingContext and navigationContext

### DIFF
--- a/Example/Sources/ViewControllers/WebViewController.swift
+++ b/Example/Sources/ViewControllers/WebViewController.swift
@@ -65,8 +65,8 @@ final class WebViewController: UIViewController {
 
 extension WebViewController: URLNavigable {
 
-  convenience init?(url: URLConvertible, values: [String: Any], userInfo: [AnyHashable: Any]?) {
-    guard let URLVaue = url.urlValue else { return nil }
+  convenience init?(navigation: Navigation) {
+    guard let URLVaue = navigation.url.urlValue else { return nil }
     self.init()
     let request = URLRequest(url: URLVaue)
     self.webView.load(request)

--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ For full documentation, see [URLNavigator Class Reference](http://cocoadocs.org/
 
 #### 3. Implementing URLNavigable
 
-View controllers should conform a protocol `URLNavigable` to be mapped with URLs. A protocol `URLNavigable` defines an failable initializer with parameter: `url`, `values` and `userInfo`.
+View controllers should conform a protocol `URLNavigable` to be mapped with URLs. A protocol `URLNavigable` defines an failable initializer with parameter `navigation` which contains `url`, `values`, `mappingContext` and `navigationContext` as properties.
 
-Parameter `url` is an URL that is passed from `URLNavigator.push()` and `URLNavigator.present()`. Parameter `values` is a dictionary that contains URL placeholder keys and values. Parameter `userInfo` is a dictionary which contains extra values passed from `push()` or `present()`.
+Property `url` is an URL that is passed from `URLNavigator.push()` and `URLNavigator.present()`. Parameter `values` is a dictionary that contains URL placeholder keys and values. Parameter `mappingContext` is a context passed from a `map()` function. Parameter `navigationContext` is a dictionary which contains extra values passed from `push()` or `present()`.
 
 ```swift
 final class UserViewController: UIViewController, URLNavigable {
@@ -64,9 +64,9 @@ final class UserViewController: UIViewController, URLNavigable {
     // Initialize here...
   }
 
-  convenience init?(url: URLConvertible, values: [String: Any], userInfo: [AnyHashable: Any]?) {
+  convenience init?(navigation: Navigation) {
     // Let's assume that the user id is required
-    guard let userID = values["id"] as? Int else { return nil }
+    guard let userID = navigation.values["id"] as? Int else { return nil }
     self.init(userID: userID)
   }
     
@@ -269,15 +269,22 @@ Navigator.map("/user/<int:id>", UserViewController.self) // `myapp://user/<int:i
 Navigator.map("http://<path>", MyWebViewController.self) // `http://<path>`
 ```
 
+#### Passing Context when Mapping
+
+```swift
+let context = Foo()
+Navigator.map("myapp://user/10", UserViewController.self, context: context)
+```
+
 
 #### Passing Extra Values when Pushing or Presenting
 
 ```swift
-let userInfo: [AnyHashable: Any] = [
+let context: [AnyHashable: Any] = [
   "fromViewController": self
 ]
-Navigator.push("myapp://user/10", userInfo: userInfo)
-Navigator.present("myapp://user/10", userInfo: userInfo)
+Navigator.push("myapp://user/10", context: context)
+Navigator.present("myapp://user/10", context: context)
 ```
 
 

--- a/Sources/Navigation.swift
+++ b/Sources/Navigation.swift
@@ -1,0 +1,27 @@
+//
+//  Navigation.swift
+//  URLNavigator
+//
+//  Created by Suyeol Jeon on 19/04/2017.
+//  Copyright © 2017 Suyeol Jeon. All rights reserved.
+//
+
+import Foundation
+
+public typealias MappingContext = Any
+public typealias NavigationContext = Any
+
+public struct Navigation {
+  /// The URL which is used to create an instance.
+  public let url: URLConvertible
+
+  /// The URL pattern placeholder values by placeholder names. For example, if the URL pattern is
+  /// `myapp://user/<int:id>` and the given URL is `myapp://user/123`, values will be `["id": 123]`.
+  public let values: [String: Any]
+
+  /// The context from mapping a view controller.
+  public let mappingContext: MappingContext?
+
+  /// The context from pushing or presenting a view controller.
+  public let navigationContext: NavigationContext?
+}

--- a/Sources/URLNavigable.swift
+++ b/Sources/URLNavigable.swift
@@ -26,14 +26,13 @@ import Foundation
 ///
 /// - seealso: `URLNavigator`
 public protocol URLNavigable {
-
-  /// Creates an instance with specified URL and returns it. Returns `nil` if the URL and the values are not met the
-  /// condition to create an instance.
+  /// Creates an instance with specified Navigation and returns it. Returns `nil` if the Navigation
+  /// and the values are not met the condition to create an instance.
   ///
   /// For example, to validate whether a value of `id` is an `Int`:
   ///
-  ///     convenience init?(url: URLConvertible, values: [String: Any], userInfo: [AnyHashable: Any]?) {
-  ///       guard let id = values["id"] as? Int else {
+  ///     convenience init?(navigation: Navigation) {
+  ///       guard let id = navigation.values["id"] as? Int else {
   ///         return nil
   ///       }
   ///       self.init(id: id)
@@ -41,10 +40,6 @@ public protocol URLNavigable {
   ///
   /// Do not call this initializer directly. It is recommended to use with `URLNavigator`.
   ///
-  /// - parameter url: The URL which is used to create an instance.
-  /// - parameter values: The URL pattern placeholder values by placeholder names. For example, if the URL pattern is
-  ///     `myapp://user/<int:id>` and the given URL is `myapp://user/123`, values will be `["id": 123]`.
-  /// - parameter userInfo: The extra parameters that you want to send when initialize this controller.
-  init?(url: URLConvertible, values: [String: Any], userInfo: [AnyHashable: Any]?)
-
+  /// - parameter navigation: The navigation information that contains url, values and context.
+  init?(navigation: Navigation)
 }

--- a/URLNavigator.xcodeproj/project.pbxproj
+++ b/URLNavigator.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		03107EE61C6366F500DF2F14 /* UIViewController+TopMostViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03107EE51C6366F500DF2F14 /* UIViewController+TopMostViewController.swift */; };
 		03107EF01C636A3D00DF2F14 /* URLNavigator.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 03107ECE1C6362E800DF2F14 /* URLNavigator.framework */; };
 		03107EFC1C67289100DF2F14 /* URLNavigatorPublicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03107EFA1C67288400DF2F14 /* URLNavigatorPublicTests.swift */; };
+		032928EA1EA76B0700E9F8F2 /* Navigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032928E91EA76B0700E9F8F2 /* Navigation.swift */; };
 		03D35E781D35289200452731 /* URLNavigator.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 03107ECE1C6362E800DF2F14 /* URLNavigator.framework */; };
 		03D35E791D35289200452731 /* URLNavigator.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 03107ECE1C6362E800DF2F14 /* URLNavigator.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		03D35E881D3528F800452731 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 03D35E7F1D3528F800452731 /* Assets.xcassets */; };
@@ -80,6 +81,7 @@
 		03107EE51C6366F500DF2F14 /* UIViewController+TopMostViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIViewController+TopMostViewController.swift"; sourceTree = "<group>"; };
 		03107EEB1C636A3D00DF2F14 /* URLNavigatorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = URLNavigatorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		03107EFA1C67288400DF2F14 /* URLNavigatorPublicTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLNavigatorPublicTests.swift; sourceTree = "<group>"; };
+		032928E91EA76B0700E9F8F2 /* Navigation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Navigation.swift; sourceTree = "<group>"; };
 		03D35E661D35209600452731 /* Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		03D35E7F1D3528F800452731 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		03D35E811D3528F800452731 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -152,6 +154,7 @@
 				03107EDF1C63653900DF2F14 /* URLNavigator.swift */,
 				03107EE11C6365BF00DF2F14 /* URLNavigable.swift */,
 				03107EE31C6365E500DF2F14 /* URLConvertible.swift */,
+				032928E91EA76B0700E9F8F2 /* Navigation.swift */,
 				03107EE51C6366F500DF2F14 /* UIViewController+TopMostViewController.swift */,
 			);
 			path = Sources;
@@ -410,6 +413,7 @@
 				02E016081D79E45E00BB7E25 /* URLMatcher.swift in Sources */,
 				03107EE41C6365E500DF2F14 /* URLConvertible.swift in Sources */,
 				03107EE21C6365BF00DF2F14 /* URLNavigable.swift in Sources */,
+				032928EA1EA76B0700E9F8F2 /* Navigation.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
## Background

URLNavigable's initializer is an independent function that can only receive url, values and userInfo parameters. It's difficult to inject dependency to the view controller's initializer. This PR adds support to pass a mapping-time context to the URLNavigable's intializer.

## Summary

* Encapsulate url, values, userInfo parameters into a separated type `Navigation`.
* Rename `userInfo` with `navigationContext`.
* Add `mappingContext` to `Navigation`.
* URLNavigable's initializer now receive `Navigation` parameter only.

## Breaking API Changes ⚠️

**URLNaviable**

```diff
- init?(url: URLConvertible, values: [String: Any], userInfo: [AnyHashable: Any]?)
+ init?(navigation: Navigation)
```

**URLNavigator**

```diff
- func push(_ url: URLConvertible, userInfo: [AnyHashable: Any]? = nil, from: UINavigationController? = nil, animated: Bool = true) -> UIViewController?
+ func push(_ url: URLConvertible, context: NavigationContext? = nil, from: UINavigationController? = nil, animated: Bool = true) -> UIViewController?
```

```diff
- func present(_ url: URLConvertible, userInfo: [AnyHashable: Any]? = nil, wrap: Bool = false, from: UIViewController? = nil, animated: Bool = true, completion: (() -> Void)? = nil) -> UIViewController?
+ func present(_ url: URLConvertible, context: NavigationContext? = nil, wrap: Bool = false, from: UIViewController? = nil, animated: Bool = true, completion: (() -> Void)? = nil) -> UIViewController?
```
