### PR TITLE
Consider an app extension environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ script:
     -destination "$DESTINATION"
     -configuration Debug
     -enableCodeCoverage YES
+    APPLICATION_EXTENSION_API_ONLY=YES
     CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO | xcpretty -c
 
 after_success:

--- a/Sources/URLNavigator/UIViewController+TopMostViewController.swift
+++ b/Sources/URLNavigator/UIViewController+TopMostViewController.swift
@@ -2,11 +2,15 @@
 import UIKit
 
 extension UIViewController {
+  private class var sharedApplication: UIApplication? {
+    let selector = NSSelectorFromString("sharedApplication")
+    return UIApplication.perform(selector)?.takeRetainedValue() as? UIApplication
+  }
+
   /// Returns the current application's top most view controller.
   open class var topMost: UIViewController? {
+    guard let currentWindows = self.sharedApplication?.windows else { return nil }
     var rootViewController: UIViewController?
-    let currentWindows = UIApplication.shared.windows
-
     for window in currentWindows {
       if let windowRootViewController = window.rootViewController {
         rootViewController = windowRootViewController


### PR DESCRIPTION
* Fixes #81
* Because of [a Swift compiler issue](https://github.com/apple/swift/pull/12410), I couldn't use `UIApplication.shared` in `topMost` even I marked the property as `@available(iOSApplicationExtension, unavailable)`. To bypass the error I used a selector to retrieve a shared UIApplication instance.
