### PR TITLE
Fix a bug that queryParameters cannot parse a query parameter that contains an url

### DIFF
--- a/Sources/URLMatcher/URLConvertible.swift
+++ b/Sources/URLMatcher/URLConvertible.swift
@@ -22,13 +22,13 @@ public protocol URLConvertible {
 extension URLConvertible {
   public var queryParameters: [String: String] {
     var parameters = [String: String]()
-    self.urlValue?.query?.components(separatedBy: "&").forEach {
-      let keyAndValue = $0.components(separatedBy: "=")
-      if keyAndValue.count == 2 {
-        let key = keyAndValue[0]
-        let value = keyAndValue[1].removingPercentEncoding ?? keyAndValue[1]
-        parameters[key] = value
-      }
+    self.urlValue?.query?.components(separatedBy: "&").forEach { component in
+      guard let separatorIndex = component.index(of: "=") else { return }
+      let keyRange = component.startIndex..<separatorIndex
+      let valueRange = component.index(after: separatorIndex)..<component.endIndex
+      let key = String(component[keyRange])
+      let value = component[valueRange].removingPercentEncoding ?? String(component[valueRange])
+      parameters[key] = value
     }
     return parameters
   }

--- a/Tests/URLMatcherTests/URLConvertibleSpec.swift
+++ b/Tests/URLMatcherTests/URLConvertibleSpec.swift
@@ -46,11 +46,11 @@ final class URLConvertibleSpec: QuickSpec {
       }
 
       context("when there is a query string") {
-        let url = "https://xoul.kr?key=this%20is%20a%20value&greeting=hello+world!&int=12&int=34"
+        let url = "https://xoul.kr?key=this%20is%20a%20value&greeting=hello+world!&int=12&int=34&url=https://foo/bar?hello=world"
 
         it("has proper keys") {
-          expect(Set(url.urlValue!.queryParameters.keys)) == ["key", "greeting", "int"]
-          expect(Set(url.urlStringValue.queryParameters.keys)) == ["key", "greeting", "int"]
+          expect(Set(url.urlValue!.queryParameters.keys)) == ["key", "greeting", "int", "url"]
+          expect(Set(url.urlStringValue.queryParameters.keys)) == ["key", "greeting", "int", "url"]
         }
 
         it("decodes a percent encoding") {
@@ -66,6 +66,10 @@ final class URLConvertibleSpec: QuickSpec {
         it("takes last value from duplicated keys") {
           expect(url.urlValue?.queryParameters["int"]) == "34"
           expect(url.urlStringValue.queryParameters["int"]) == "34"
+        }
+
+        it("has an url") {
+          expect(url.urlValue?.queryParameters["url"]) == "https://foo/bar?hello=world"
         }
       }
     }


### PR DESCRIPTION
Thanks to @innocarpe
