### PR TITLE
Add steps for custom value converters in Readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,20 +221,17 @@ Custom validators can be defined for placeholders.
 
 For example, the placeholder `<department>` should only contain the strings `['men','women','kids']`. If it doesn't contain any of these, the URL pattern should not match.
 
-```swift
-let deptartmentType: [String: URLValueConverter] = [
-  "dept-type": { pathComponents, index in
-                  let departments = ["men","women","kids"]
-                  if (departments.contains(pathComponents[index])) {
-                    return pathComponents[index]
-                  }}
-]
-```
-
-Then include the validator on your instance of `Navigator`. You can merge your new validators with the default validators, or overwrite the existing ones.
+Add the custom value converter to the `[String: URLValueConverter]` dictionary on your instance of `Navigator`.
 
 ```swift
-navigator.matcher.valueConverters.merge(deptartmentType, uniquingKeysWith: { (current, _) in current })
+navigator.matcher.valueConverters["dept-type"] = { pathComponents, index in
+  let departments = ["men", "women", "kids"]
+  if departments.contains(pathComponents[index]) {
+    return pathComponents[index]
+  } else {
+    return nil
+  }
+}
 ```
 
 You will then be able to add the validator to a placeholder in the same way that standard validators are included.
@@ -247,7 +244,7 @@ For example, `myapp://user/browse/<department:dept-type>` matches with:
 But it doesn't match with:
 - `myapp://user/browse/babies`
 
-For additional information, see the [implementation](https://github.com/devxoul/URLNavigator/blob/master/Sources/URLMatcher/URLMatcher.swift#L10) of default validators.
+For additional information, see the [implementation](https://github.com/devxoul/URLNavigator/blob/master/Sources/URLMatcher/URLMatcher.swift) of default validators.
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -216,6 +216,40 @@ Navigator.open("myapp://alert?title=Hi", context: context)
 ```
 
 
+#### Setting custom validators for placeholders
+Custom validators can be defined for placeholders.
+
+For example, the placeholder `<department>` should only contain the strings `['men','women','kids']`. If it doesn't contain any of these, the URL pattern should not match.
+
+```swift
+let deptartmentType: [String: URLValueConverter] = [
+  "dept-type": { pathComponents, index in
+                  let departments = ["men","women","kids"]
+                  if (departments.contains(pathComponents[index])) {
+                    return pathComponents[index]
+                  }}
+]
+```
+
+Then include the validator on your instance of `Navigator`. You can merge your new validators with the default validators, or overwrite the existing ones.
+
+```swift
+navigator.matcher.valueConverters.merge(deptartmentType, uniquingKeysWith: { (current, _) in current })
+```
+
+You will then be able to add the validator to a placeholder in the same way that standard validators are included.
+
+For example, `myapp://user/browse/<department:dept-type>` matches with:
+- `myapp://user/browse/men`
+- `myapp://user/browse/women`
+- `myapp://user/browse/kids`
+
+But it doesn't match with:
+- `myapp://user/browse/babies`
+
+For additional information, see the [implementation](https://github.com/devxoul/URLNavigator/blob/master/Sources/URLMatcher/URLMatcher.swift#L10) of default validators.
+
+
 ## License
 
 URLNavigator is under MIT license. See the [LICENSE](LICENSE) file for more info.


### PR DESCRIPTION
### Context
Users should be able to easily know how to add custom validators to placeholders, and expand on the default convertors.

### Changes
- Included steps for custom validator/value converter in README.