### PR TITLE
Fix URL matching rule devxoul#111

### DIFF
--- a/Sources/URLMatcher/URLMatcher.swift
+++ b/Sources/URLMatcher/URLMatcher.swift
@@ -56,7 +56,7 @@ open class URLMatcher {
     for candidate in candidates {
       guard scheme == candidate.urlValue?.scheme else { continue }
       if let result = self.match(stringPathComponents, with: candidate) {
-        return result
+        results.append(result)
       }
     }
 


### PR DESCRIPTION
Fix URL matching, placeholder should have higher priority then parameter when input URL matches multiple patterns. E.g. `/test/test` link should match `/test/test` pattern not `/test/<testparam>` pattern.

Other examples: devxoul#111