### PR TITLE
Fix a bug that pattern matches when the url contains another url

### DIFF
--- a/Sources/URLMatcher/URLMatcher.swift
+++ b/Sources/URLMatcher/URLMatcher.swift
@@ -128,9 +128,14 @@ open class URLMatcher {
   }
 
   func stringPathComponents(from url: URLConvertible) -> [String] {
-    return url.urlStringValue.components(separatedBy: "/").lazy
-      .filter { !$0.isEmpty }
-      .filter { !$0.hasSuffix(":") }
+    return url.urlStringValue.components(separatedBy: "/").lazy.enumerated()
+      .filter { index, component in !component.isEmpty }
+      .filter { index, component in !self.isScheme(index, component) }
+      .map { index, component in component }
+  }
+
+  private func isScheme(_ index: Int, _ component: String) -> Bool {
+    return index == 0 && component.hasSuffix(":")
   }
 
   func pathComponents(from url: URLPattern) -> [URLPathComponent] {

--- a/Tests/URLMatcherTests/URLMatcherSpec.swift
+++ b/Tests/URLMatcherTests/URLMatcherSpec.swift
@@ -38,7 +38,7 @@ final class URLMatcherSpec: QuickSpec {
       expect(result).to(beNil())
     }
 
-    fit("returns a result for totally matching url") {
+    it("returns a result for totally matching url") {
       let candidates = ["myapp://hello/<name>", "myapp://hello/world"]
       let result = matcher.match("myapp://hello/world", from: candidates)
       expect(result).notTo(beNil())
@@ -46,7 +46,7 @@ final class URLMatcherSpec: QuickSpec {
       expect(result?.values.count) == 0
     }
 
-    fit("returns a result for totally matching url2") {
+    it("returns a result for the longest matching url") {
       let candidates = ["myapp://<path:path>", "myapp://hello/<name>"]
       let result = matcher.match("myapp://hello/world", from: candidates)
       expect(result).notTo(beNil())

--- a/Tests/URLMatcherTests/URLMatcherSpec.swift
+++ b/Tests/URLMatcherTests/URLMatcherSpec.swift
@@ -165,5 +165,11 @@ final class URLMatcherSpec: QuickSpec {
         let result2 = matcher.match("http://host/anything", from: candidates2)
         expect(result1?.pattern).to(equal(result2?.pattern))
     }
+
+    it("returns nil when there is anotehr url in the path (#123)") {
+      let candidates = ["myapp://browser/<url>"]
+      let result = matcher.match("myapp://browser/http://google.fr", from: candidates)
+      expect(result).to(beNil())
+    }
   }
 }


### PR DESCRIPTION
Found a bug in #123 thanks to @amaurydavid

`myapp://browser/<string:url>` should not match with:
`myapp://browser/http://google.fr`