### PR TITLE
Change wrong protocol name in the example project

### DIFF
--- a/Example/Sources/AppDelegate.swift
+++ b/Example/Sources/AppDelegate.swift
@@ -14,7 +14,7 @@ import URLNavigator
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
   var window: UIWindow?
-  private var navigator: NavigatorType?
+  private var navigator: NavigatorProtocol?
 
   func application(
     _ application: UIApplication,

--- a/Example/Sources/Navigator/NavigationMap.swift
+++ b/Example/Sources/Navigator/NavigationMap.swift
@@ -12,7 +12,7 @@ import UIKit
 import URLNavigator
 
 enum NavigationMap {
-  static func initialize(navigator: NavigatorType) {
+  static func initialize(navigator: NavigatorProtocol) {
     navigator.register("navigator://user/<username>") { url, values, context in
       guard let username = values["username"] as? String else { return nil }
       return UserViewController(navigator: navigator, username: username)
@@ -37,13 +37,13 @@ enum NavigationMap {
     return SFSafariViewController(url: url)
   }
 
-  private static func alert(navigator: NavigatorType) -> URLOpenHandlerFactory {
+  private static func alert(navigator: NavigatorProtocol) -> URLOpenHandlerFactory {
     return { url, values, context in
       guard let title = url.queryParameters["title"] else { return false }
       let message = url.queryParameters["message"]
       let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
       alertController.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
-      navigator.present(alertController)
+      navigator.present(alertController, wrap: nil, from: nil, animated: true, completion: nil)
       return true
     }
   }

--- a/Example/Sources/ViewControllers/UserListViewController.swift
+++ b/Example/Sources/ViewControllers/UserListViewController.swift
@@ -14,7 +14,7 @@ class UserListViewController: UIViewController {
 
   // MARK: Properties
 
-  private let navigator: NavigatorType
+  private let navigator: NavigatorProtocol
   let users = [
     User(name: "devxoul", urlString: "navigator://user/devxoul"),
     User(name: "apple", urlString: "navigator://user/apple"),
@@ -32,7 +32,7 @@ class UserListViewController: UIViewController {
 
   // MARK: Initializing
 
-  init(navigator: NavigatorType) {
+  init(navigator: NavigatorProtocol) {
     self.navigator = navigator
     super.init(nibName: nil, bundle: nil)
     self.title = "GitHub Users"

--- a/Example/Sources/ViewControllers/UserViewController.swift
+++ b/Example/Sources/ViewControllers/UserViewController.swift
@@ -14,7 +14,7 @@ final class UserViewController: UIViewController {
 
   // MARK: Properties
 
-  private let navigator: NavigatorType
+  private let navigator: NavigatorProtocol
   let username: String
   var repos = [Repo]()
 
@@ -26,7 +26,7 @@ final class UserViewController: UIViewController {
 
   // MARK: Initializing
 
-  init(navigator: NavigatorType, username: String) {
+  init(navigator: NavigatorProtocol, username: String) {
     self.navigator = navigator
     self.username = username
     super.init(nibName: nil, bundle: nil)


### PR DESCRIPTION
Current Example Project can't work anymore. NavigatorType needs to be replaced with NavigatorProtocol.