### PR TITLE
Downgrade swift tools version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.8
+// swift-tools-version: 5.7.1
 
 import PackageDescription
 


### PR DESCRIPTION
## Background

- Github actions mac os runner not support swift tools version 5.8.0